### PR TITLE
Integrate @wix-astro to load blog posts

### DIFF
--- a/astro/blog/.env.template
+++ b/astro/blog/.env.template
@@ -1,2 +1,2 @@
 # this is a template, copy to .env.local with proper values for local development (do not store APIs Key in git!)
-PUBLIC_WIX_CLIENT_ID=
+WIX_CLIENT_ID=

--- a/astro/blog/package.json
+++ b/astro/blog/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.11",
     "@astrojs/sitemap": "^3.2.1",
-    "@wix/astro": "^0.2.1",
-    "@wix/astro-ricos": "^0.0.1",
+    "@wix/astro": "^0.2.2",
+    "@wix/astro-ricos": "^0.0.2",
     "astro": "^5.2.4"
   },
   "publishConfig": {

--- a/astro/blog/package.json
+++ b/astro/blog/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.11",
     "@astrojs/sitemap": "^3.2.1",
-    "@wix/astro-blog-loader": "^0.0.1",
+    "@wix/astro": "^0.2.1",
     "@wix/astro-ricos": "^0.0.1",
     "astro": "^5.2.4"
   },

--- a/astro/blog/src/content.config.ts
+++ b/astro/blog/src/content.config.ts
@@ -1,46 +1,17 @@
 import { wixBlogLoader } from "@wix/astro-blog-loader";
-import type { Loader, LoaderContext } from "astro/loaders";
 import { z } from "astro/zod";
 import { defineCollection } from "astro:content";
 
-export function blogLoader(): Loader {
-  return {
-    name: "blog-loader",
-    load: async (context: LoaderContext): Promise<void> => {
-      await wixBlogLoader().load(context);
-      const items = context.store.values();
-      context.store.clear();
-
-      for (const item of items) {
-        const { data: sdkData } = item as any;
-        const id = (sdkData.slug || item.id) as string;
-
-        const data = await context.parseData({
-          id,
-          data: {
-            title: sdkData.title,
-            description: sdkData.excerpt,
-            pubDate: new Date(sdkData.firstPublishedDate),
-            updatedDate: new Date(sdkData.lastPublishedDate),
-            heroImage: sdkData.mediaUrl,
-            richContent: sdkData.richContent,
-          },
-        });
-
-        const digest = context.generateDigest(data);
-
-        context.store.set({
-          id,
-          data,
-          digest,
-        });
-      }
-    },
-  };
-}
-
 const blog = defineCollection({
-  loader: blogLoader(),
+  loader: wixBlogLoader((item) => ({
+    id: item.slug,
+    title: item.title,
+    description: item.excerpt,
+    pubDate: new Date(item.firstPublishedDate),
+    updatedDate: new Date(item.lastPublishedDate),
+    heroImage: item.mediaUrl,
+    richContent: item.richContent,
+  })),
   schema: z.object({
     title: z.string(),
     description: z.string(),

--- a/astro/blog/src/content.config.ts
+++ b/astro/blog/src/content.config.ts
@@ -1,4 +1,4 @@
-import { wixBlogLoader } from "@wix/astro-blog-loader";
+import { wixBlogLoader } from "@wix/astro/loaders";
 import { z } from "astro/zod";
 import { defineCollection } from "astro:content";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,17 +12,56 @@
         "astro/*"
       ]
     },
+    "../headless-integrations/packages/@wix-astro": {
+      "name": "@wix/astro",
+      "version": "0.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.3.0",
+        "@astrojs/underscore-redirects": "^0.4.0",
+        "@cloudflare/kv-asset-handler": "^0.3.4",
+        "@cloudflare/workers-types": "^4.20241224.0",
+        "@wix/sdk": "^1.15.9",
+        "esm-resolve": "^1.0.11",
+        "globby": "^14.0.2",
+        "magic-string": "^0.30.17"
+      },
+      "devDependencies": {
+        "@types/node": "^20.9.0",
+        "astro": "^5.1.8",
+        "typescript": "^5.7.3"
+      },
+      "peerDependencies": {
+        "astro": "^5.1.8"
+      }
+    },
+    "../headless-integrations/packages/astro-blog-loader": {
+      "name": "@wix/astro-blog-loader",
+      "version": "0.0.1",
+      "extraneous": true,
+      "dependencies": {
+        "@wix/blog": "^1.0.340",
+        "@wix/sdk": "^1.15.9"
+      },
+      "peerDependencies": {
+        "astro": "^5.1.8",
+        "typescript": "^5.7.3"
+      }
+    },
     "astro/blog": {
+      "name": "@wix/astro-blog-template",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/rss": "^4.0.11",
         "@astrojs/sitemap": "^3.2.1",
-        "@wix/astro-blog-loader": "^0.0.1",
+        "@wix/astro": "^0.2.1",
         "@wix/astro-ricos": "^0.0.1",
         "astro": "^5.2.4"
       }
     },
     "astro/commerce": {
+      "name": "astro-vercel-commerce",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
@@ -41,18 +80,16 @@
         "typescript": "^5.6.3"
       },
       "devDependencies": {
-        "@wix/cli-edge": "^1.1.58"
+        "@wix/cli-edge": "^1.1.60"
       }
     },
     "astro/commerce/node_modules/@astrojs/internal-helpers": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.4.2.tgz",
-      "integrity": "sha512-EdDWkC3JJVcpGpqJAU/5hSk2LKXyG3mNGkzGoAuyK+xoPHbaVdSuIWoN1QTnmK3N/gGfaaAfM8gO2KDCAW7S3w=="
+      "license": "MIT"
     },
     "astro/commerce/node_modules/@astrojs/markdown-remark": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.0.1.tgz",
-      "integrity": "sha512-CTSYijj25NfxgZi15TU3CwPwgyD1/7yA3FcdcNmB9p94nydupiUbrIiq3IqeTp2m5kCVzxbPZeC7fTwEOaNyGw==",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/prism": "3.2.0",
         "github-slugger": "^2.0.0",
@@ -75,346 +112,15 @@
         "vfile": "^6.0.3"
       }
     },
-    "astro/commerce/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "astro/commerce/node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "astro/commerce/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -422,16 +128,12 @@
     },
     "astro/commerce/node_modules/@wix/redirects": {
       "version": "1.0.60",
-      "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.60.tgz",
-      "integrity": "sha512-C7kA8N1OzVgG3ezuDpVsAfWiVdxeL5bXT9Ysuyfuld4JvOGH1zr1vx+iVVITVQedqz3yw856jPdHjJlWDmVSAg==",
       "dependencies": {
         "@wix/redirects_redirects": "1.0.29"
       }
     },
     "astro/commerce/node_modules/@wix/redirects_redirects": {
       "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@wix/redirects_redirects/-/redirects_redirects-1.0.29.tgz",
-      "integrity": "sha512-RDSDimwF0ffYLZ2x/qAi3ecNp7M0bSvYnjm/fWqldyhwS22ibpxemD8utoPgSbM0Cs+MHmG/tGu3nETdoICG6A==",
       "dependencies": {
         "@wix/metro-runtime": "^1.1792.0",
         "@wix/motion-edm-autogen-query-wrapper": "^1.0.37",
@@ -441,8 +143,7 @@
     },
     "astro/commerce/node_modules/astro": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.1.1.tgz",
-      "integrity": "sha512-prpWC2PRs4P3FKQg6gZaU+VNMqbZi5pDvORGB2nrjfRjkrvF6/l4BqhvkJ6YQ0Ohm5rIMVz8ljgaRI77mLHbwg==",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.10.3",
         "@astrojs/internal-helpers": "0.4.2",
@@ -518,9 +219,8 @@
     },
     "astro/commerce/node_modules/esbuild": {
       "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -555,8 +255,7 @@
     },
     "astro/commerce/node_modules/yocto-spinner": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.1.2.tgz",
-      "integrity": "sha512-VfmLIh/ZSZOJnVRQZc/dvpPP90lWL4G0bmxQMP0+U/2vKBA8GSpcBuWv17y7F+CZItRuO97HN1wdbb4p10uhOg==",
+      "license": "MIT",
       "dependencies": {
         "yoctocolors": "^2.1.1"
       },
@@ -569,8 +268,7 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -580,8 +278,7 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -592,8 +289,7 @@
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.4.tgz",
-      "integrity": "sha512-IOheHwCtpUfvogHHsvu0AbeRZEnjJg3MopdLddkJE70mULItS/Vh37BHcI00mcOJcH1vhD3odbpvWokpxam7xA==",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/language-server": "^2.15.0",
         "chokidar": "^4.0.1",
@@ -609,8 +305,7 @@
     },
     "node_modules/@astrojs/check/node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -623,8 +318,7 @@
     },
     "node_modules/@astrojs/check/node_modules/readdirp": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
-      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -635,18 +329,15 @@
     },
     "node_modules/@astrojs/compiler": {
       "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.10.3.tgz",
-      "integrity": "sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw=="
+      "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.5.1.tgz",
-      "integrity": "sha512-M7rAge1n2+aOSxNvKUFa0u/KFn0W+sZy7EW91KOSERotm2Ti8qs+1K0xx3zbOxtAVrmJb5/J98eohVvvEqtNkw=="
+      "license": "MIT"
     },
     "node_modules/@astrojs/language-server": {
       "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.15.4.tgz",
-      "integrity": "sha512-JivzASqTPR2bao9BWsSc/woPHH7OGSGc9aMxXL4U6egVTqBycB3ZHdBJPuOCVtcGLrzdWTosAqVPz1BVoxE0+A==",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.10.3",
         "@astrojs/yaml2ts": "^0.2.2",
@@ -685,8 +376,7 @@
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.1.0.tgz",
-      "integrity": "sha512-emZNNSTPGgPc3V399Cazpp5+snogjaF04ocOSQn9vy3Kw/eIC4vTQjXOrWDEoSEy+AwPDZX9bQ4wd3bxhpmGgQ==",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/prism": "3.2.0",
         "github-slugger": "^2.0.0",
@@ -712,8 +402,7 @@
     },
     "node_modules/@astrojs/prism": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.2.0.tgz",
-      "integrity": "sha512-GilTHKGCW6HMq7y3BUv9Ac7GMe/MO9gi9GW62GzKtth0SwukCu/qp2wLiGpEujhY+VVhaG9v7kv/5vFzvf4NYw==",
+      "license": "MIT",
       "dependencies": {
         "prismjs": "^1.29.0"
       },
@@ -723,8 +412,7 @@
     },
     "node_modules/@astrojs/react": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.1.2.tgz",
-      "integrity": "sha512-Slw8Bho50w1+rYnSnDl5PDAUikSOEItx5DEJU5OgmarTirBr1audIb2DgC8faAGcGkq5WhuUVsSiq/TmSORlwA==",
+      "license": "MIT",
       "dependencies": {
         "@vitejs/plugin-react": "^4.3.4",
         "ultrahtml": "^1.5.3",
@@ -742,8 +430,7 @@
     },
     "node_modules/@astrojs/rss": {
       "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.11.tgz",
-      "integrity": "sha512-3e3H8i6kc97KGnn9iaZBJpIkdoQi8MmR5zH5R+dWsfCM44lLTszOqy1OBfGGxDt56mpQkYVtZJWoxMyWuUZBfw==",
+      "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^4.5.0",
         "kleur": "^4.1.5"
@@ -751,8 +438,7 @@
     },
     "node_modules/@astrojs/sitemap": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.2.1.tgz",
-      "integrity": "sha512-uxMfO8f7pALq0ADL6Lk68UV6dNYjJ2xGUzyjjVj60JLBs5a6smtlkBYv3tQ0DzoqwS7c9n4FUx5lgv0yPo/fgA==",
+      "license": "MIT",
       "dependencies": {
         "sitemap": "^8.0.0",
         "stream-replace-string": "^2.0.0",
@@ -761,8 +447,7 @@
     },
     "node_modules/@astrojs/tailwind": {
       "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-5.1.4.tgz",
-      "integrity": "sha512-EJ3uoTZZr0RYwTrVS2HgYN0+VbXvg7h87AtwpD5OzqS3GyMwRmzfOwHfORTxoWGQRrY9k/Fi+Awk60kwpvRL5Q==",
+      "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
@@ -775,8 +460,7 @@
     },
     "node_modules/@astrojs/telemetry": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.2.0.tgz",
-      "integrity": "sha512-wxhSKRfKugLwLlr4OFfcqovk+LIFtKwLyGPqMsv+9/ibqqnW3Gv7tBhtKEb0gAyUAC4G9BTVQeQahqnQAhd6IQ==",
+      "license": "MIT",
       "dependencies": {
         "ci-info": "^4.1.0",
         "debug": "^4.3.7",
@@ -792,21 +476,18 @@
     },
     "node_modules/@astrojs/underscore-redirects": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-0.4.0.tgz",
-      "integrity": "sha512-Urt32++4ql0IFTTNejnRIN7LPJ6YzU9QXLcc4RXm5or1RLPnQBKVrLvmDxKx3eT72l7ZAi6W4L5E7pcbWbYDRA=="
+      "license": "MIT"
     },
     "node_modules/@astrojs/yaml2ts": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.2.tgz",
-      "integrity": "sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==",
+      "license": "MIT",
       "dependencies": {
         "yaml": "^2.5.0"
       }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -818,16 +499,14 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
-      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
       "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
-      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -855,16 +534,14 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
       "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
-      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.26.5",
         "@babel/types": "^7.26.5",
@@ -878,8 +555,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
-      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
@@ -893,24 +569,21 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -921,8 +594,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9",
@@ -937,40 +609,35 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
       "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
         "@babel/types": "^7.26.7"
@@ -981,8 +648,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
-      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.7"
       },
@@ -995,8 +661,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz",
-      "integrity": "sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1009,8 +674,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.25.9.tgz",
-      "integrity": "sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1023,8 +687,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1034,8 +697,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.9",
         "@babel/parser": "^7.25.9",
@@ -1047,8 +709,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "@babel/generator": "^7.26.5",
@@ -1064,8 +725,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -1076,8 +736,7 @@
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
-      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "mime": "^3.0.0"
       },
@@ -1087,29 +746,25 @@
     },
     "node_modules/@cloudflare/workers-types": {
       "version": "4.20250204.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250204.0.tgz",
-      "integrity": "sha512-mWoQbYaP+nYztx9I7q9sgaiNlT54Cypszz0RfzMxYnT5W3NXDuwGcjGB+5B5H5VB8tEC2dYnBRpa70lX94ueaQ=="
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
-      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "license": "MIT",
       "dependencies": {
         "@emmetio/scanner": "^1.0.4"
       }
     },
     "node_modules/@emmetio/css-abbreviation": {
       "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
-      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "license": "MIT",
       "dependencies": {
         "@emmetio/scanner": "^1.0.4"
       }
     },
     "node_modules/@emmetio/css-parser": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.0.tgz",
-      "integrity": "sha512-z7wkxRSZgrQHXVzObGkXG+Vmj3uRlpM11oCZ9pbaz0nFejvCDmAiNDpY75+wgXOcffKpj4rzGtwGaZxfJKsJxw==",
+      "license": "MIT",
       "dependencies": {
         "@emmetio/stream-reader": "^2.2.0",
         "@emmetio/stream-reader-utils": "^0.1.0"
@@ -1117,406 +772,32 @@
     },
     "node_modules/@emmetio/html-matcher": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
-      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "license": "ISC",
       "dependencies": {
         "@emmetio/scanner": "^1.0.0"
       }
     },
     "node_modules/@emmetio/scanner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
-      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
+      "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
-      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="
+      "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader-utils": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
-      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -1524,11 +805,10 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1543,331 +823,23 @@
         "@img/sharp-libvips-darwin-arm64": "1.0.4"
       }
     },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
-      }
-    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
       "cpu": [
         "arm64"
       ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1882,13 +854,11 @@
     },
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1903,8 +873,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1919,8 +888,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1932,29 +900,25 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1962,8 +926,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1974,16 +937,14 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -1994,13 +955,11 @@
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
-      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -2008,8 +967,7 @@
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -2029,246 +987,26 @@
     },
     "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.0.tgz",
-      "integrity": "sha512-Eeao7ewDq79jVEsrtWIj5RNqB8p2knlm9fhR6uJ2gqP7UfbLrTrxevudVrEPDM7Wkpn/HpRC2QfazH7MXLz3vQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.0.tgz",
-      "integrity": "sha512-yVh0Kf1f0Fq4tWNf6mWcbQBCLDpDrDEl88lzPgKhrgTcDrTtlmun92ywEF9dCjmYO3EFiSuJeeo9cYRxl2FswA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ]
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.0.tgz",
-      "integrity": "sha512-gCs0ErAZ9s0Osejpc3qahTsqIPUDjSKIyxK/0BGKvL+Tn0n3Kwvj8BrCv7Y5sR1Ypz1K2qz9Ny0VvkVyoXBVUQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.0.tgz",
-      "integrity": "sha512-aIB5Anc8hngk15t3GUkiO4pv42ykXHfmpXGS+CzM9CTyiWyT8HIS5ygRAy7KcFb/wiw4Br+vh1byqcHRTfq2tQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.0.tgz",
-      "integrity": "sha512-kpdsUdMlVJMRMaOf/tIvxk8TQdzHhY47imwmASOuMajg/GXpw8GKNd8LNwIHE5Yd1onehNpcUB9jHY6wgw9nHQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.0.tgz",
-      "integrity": "sha512-D0RDyHygOBCQiqookcPevrvgEarN0CttBecG4chOeIYCNtlKHmf5oi5kAVpXV7qs0Xh/WO2RnxeicZPtT50V0g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.0.tgz",
-      "integrity": "sha512-mCIw8j5LPDXmCOW8mfMZwT6F/Kza03EnSr4wGYEswrEfjTfVsFOxvgYfuRMxTuUF/XmRb9WSMD5GhCWDe2iNrg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.0.tgz",
-      "integrity": "sha512-AwwldAu4aCJPob7zmjuDUMvvuatgs8B/QiVB0KwkUarAcPB3W+ToOT+18TQwY4z09Al7G0BvCcmLRop5zBLTag==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.0.tgz",
-      "integrity": "sha512-e7kDUGVP+xw05pV65ZKb0zulRploU3gTu6qH1qL58PrULDGxULIS0OSDQJLH7WiFnpd3ZKUU4VM3u/Z7Zw+e7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.0.tgz",
-      "integrity": "sha512-SXYJw3zpwHgaBqTXeAZ31qfW/v50wq4HhNVvKFhRr5MnptRX2Af4KebLWR1wpxGJtLgfS2hEPuALRIY3LPAAcA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.0.tgz",
-      "integrity": "sha512-e5XiCinINCI4RdyU3sFyBH4zzz7LiQRvHqDtRe9Dt8o/8hTBaYpdPimayF00eY2qy5j4PaaWK0azRgUench6WQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.0.tgz",
-      "integrity": "sha512-3SWN3e0bAsm9ToprLFBSro8nJe6YN+5xmB11N4FfNf92wvLye/+Rh5JGQtKOpwLKt6e61R1RBc9g+luLJsc23A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.0.tgz",
-      "integrity": "sha512-B1Oqt3GLh7qmhvfnc2WQla4NuHlcxAD5LyueUi5WtMc76ZWY+6qDtQYqnxARx9r+7mDGfamD+8kTJO0pKUJeJA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.0.tgz",
-      "integrity": "sha512-UfUCo0h/uj48Jq2lnhX0AOhZPSTAq3Eostas+XZ+GGk22pI+Op1Y6cxQ1JkUuKYu2iU+mXj1QjPrZm9nNWV9rg==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.0.tgz",
-      "integrity": "sha512-chZLTUIPbgcpm+Z7ALmomXW8Zh+wE2icrG+K6nt/HenPLmtwCajhQC5flNSk1Xy5EDMt/QAOz2MhzfOfJOLSiA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.0.tgz",
-      "integrity": "sha512-jo0UolK70O28BifvEsFD/8r25shFezl0aUk2t0VJzREWHkq19e+pcLu4kX5HiVXNz5qqkD+aAq04Ct8rkxgbyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.0.tgz",
-      "integrity": "sha512-Vmg0NhAap2S54JojJchiu5An54qa6t/oKT7LmDaWggpIcaiL8WcWHEN6OQrfTdL6mQ2GFyH7j2T5/3YPEDOOGA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.0.tgz",
-      "integrity": "sha512-CV2aqhDDOsABKHKhNcs1SZFryffQf8vK2XrxP6lxC99ELZAdvsDgPklIBfd65R8R+qvOm1SmLaZ/Fdq961+m7A==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.0.tgz",
-      "integrity": "sha512-g2ASy1QwHP88y5KWvblUolJz9rN+i4ZOsYzkEwcNfaNooxNUXG+ON6F5xFo0NIItpHqxcdAyls05VXpBnludGw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.5.tgz",
-      "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A=="
+      "license": "MIT"
     },
     "node_modules/@shikijs/core": {
       "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
-      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
+      "license": "MIT",
       "dependencies": {
         "@shikijs/engine-javascript": "1.29.2",
         "@shikijs/engine-oniguruma": "1.29.2",
@@ -2280,8 +1018,7 @@
     },
     "node_modules/@shikijs/engine-javascript": {
       "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
-      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
+      "license": "MIT",
       "dependencies": {
         "@shikijs/types": "1.29.2",
         "@shikijs/vscode-textmate": "^10.0.1",
@@ -2290,8 +1027,7 @@
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "license": "MIT",
       "dependencies": {
         "@shikijs/types": "1.29.2",
         "@shikijs/vscode-textmate": "^10.0.1"
@@ -2299,24 +1035,21 @@
     },
     "node_modules/@shikijs/langs": {
       "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
-      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "license": "MIT",
       "dependencies": {
         "@shikijs/types": "1.29.2"
       }
     },
     "node_modules/@shikijs/themes": {
       "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
-      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "license": "MIT",
       "dependencies": {
         "@shikijs/types": "1.29.2"
       }
     },
     "node_modules/@shikijs/types": {
       "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
@@ -2324,13 +1057,11 @@
     },
     "node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
-      "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg=="
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2340,16 +1071,14 @@
     },
     "node_modules/@tailwindcss/container-queries": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
-      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
-      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "license": "MIT",
       "dependencies": {
         "lodash.castarray": "^4.4.0",
         "lodash.isplainobject": "^4.0.6",
@@ -2362,8 +1091,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -2374,16 +1102,14 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -2391,71 +1117,61 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
-      "integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
+      "license": "MIT"
     },
     "node_modules/@types/nlcst": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
-      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
     },
     "node_modules/@types/node": {
       "version": "22.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
-      "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/react": {
       "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
-      "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2463,8 +1179,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.3.tgz",
-      "integrity": "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==",
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2472,26 +1187,22 @@
     },
     "node_modules/@types/sax": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
-      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz",
-      "integrity": "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==",
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.0",
         "@babel/plugin-transform-react-jsx-self": "^7.25.9",
@@ -2508,8 +1219,7 @@
     },
     "node_modules/@volar/kit": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.11.tgz",
-      "integrity": "sha512-ups5RKbMzMCr6RKafcCqDRnJhJDNWqo2vfekwOAj6psZ15v5TlcQFQAyokQJ3wZxVkzxrQM+TqTRDENfQEXpmA==",
+      "license": "MIT",
       "dependencies": {
         "@volar/language-service": "2.4.11",
         "@volar/typescript": "2.4.11",
@@ -2523,16 +1233,14 @@
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
-      "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
+      "license": "MIT",
       "dependencies": {
         "@volar/source-map": "2.4.11"
       }
     },
     "node_modules/@volar/language-server": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.11.tgz",
-      "integrity": "sha512-W9P8glH1M8LGREJ7yHRCANI5vOvTrRO15EMLdmh5WNF9sZYSEbQxiHKckZhvGIkbeR1WAlTl3ORTrJXUghjk7g==",
+      "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.11",
         "@volar/language-service": "2.4.11",
@@ -2547,8 +1255,7 @@
     },
     "node_modules/@volar/language-service": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.11.tgz",
-      "integrity": "sha512-KIb6g8gjUkS2LzAJ9bJCLIjfsJjeRtmXlu7b2pDFGD3fNqdbC53cCAKzgWDs64xtQVKYBU13DLWbtSNFtGuMLQ==",
+      "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.11",
         "vscode-languageserver-protocol": "^3.17.5",
@@ -2558,13 +1265,11 @@
     },
     "node_modules/@volar/source-map": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
-      "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ=="
+      "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
-      "integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
+      "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.11",
         "path-browserify": "^1.0.1",
@@ -2573,8 +1278,7 @@
     },
     "node_modules/@vscode/emmet-helper": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
-      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "license": "MIT",
       "dependencies": {
         "emmet": "^2.4.3",
         "jsonc-parser": "^2.3.0",
@@ -2585,8 +1289,7 @@
     },
     "node_modules/@vscode/l10n": {
       "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
-      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
+      "license": "MIT"
     },
     "node_modules/@wix/astro": {
       "version": "0.2.1",
@@ -2606,27 +1309,12 @@
         "astro": "^5.1.1"
       }
     },
-    "node_modules/@wix/astro-blog-loader": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@wix/astro-blog-loader/-/astro-blog-loader-0.0.1.tgz",
-      "integrity": "sha512-Xp2YFyf5ILW3YzVV18sQscm7cznPMrz3N/YKgwQMgs6GStnWyTfD3cbn57vWvH3N0C/aaLorbl0aRtnvul3dxQ==",
-      "dependencies": {
-        "@wix/blog": "^1.0.340",
-        "@wix/sdk": "^1.15.9"
-      },
-      "peerDependencies": {
-        "astro": "^5.1.8",
-        "typescript": "^5.7.3"
-      }
-    },
     "node_modules/@wix/astro-blog-template": {
       "resolved": "astro/blog",
       "link": true
     },
     "node_modules/@wix/astro-ricos": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@wix/astro-ricos/-/astro-ricos-0.0.1.tgz",
-      "integrity": "sha512-nOi56beouAt6/pFUR2VTzdv8HKsfBG2XLy09QoBxD+2J/h6Q1Et/mqEdQiUU/EBB424g+IESzcsW9NoZdkq0+g==",
       "dependencies": {
         "@wix/sdk": "^1.15.9"
       },
@@ -2636,80 +1324,10 @@
     },
     "node_modules/@wix/astro/node_modules/@astrojs/internal-helpers": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.3.0.tgz",
-      "integrity": "sha512-tGmHvrhpzuz0JBHaJX8GywN9g4rldVNHtkoVDC3m/DdzBO70jGoVuc0uuNVglRYnsdwkbG0K02Iw3nOOR3/Y4g=="
-    },
-    "node_modules/@wix/blog": {
-      "version": "1.0.343",
-      "resolved": "https://registry.npmjs.org/@wix/blog/-/blog-1.0.343.tgz",
-      "integrity": "sha512-+oh8tdxs24wVZ0YFnfGubcYu0hAq5wT3PszgDpy2NDWiDagF91OqLgfRo4Hvpv2mJFTAVpHEFE9+qOBoMT0+vA==",
-      "dependencies": {
-        "@wix/blog_blog-cache": "1.0.13",
-        "@wix/blog_blog-importer": "1.0.27",
-        "@wix/blog_categories": "1.0.59",
-        "@wix/blog_draft-posts": "1.0.60",
-        "@wix/blog_posts": "1.0.69",
-        "@wix/blog_tags": "1.0.66"
-      }
-    },
-    "node_modules/@wix/blog_blog-cache": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@wix/blog_blog-cache/-/blog_blog-cache-1.0.13.tgz",
-      "integrity": "sha512-1wGLhyGYrIo013tHBbWDcGweW7hs5mgwaQ6zw4wC5Rp+HHQbpvnnmJbvQIu62bqXgVi0kg1EVYx+k0lKQovBpg==",
-      "dependencies": {
-        "@wix/sdk-runtime": "^0.3.22",
-        "@wix/sdk-types": "^1.12.4"
-      }
-    },
-    "node_modules/@wix/blog_blog-importer": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@wix/blog_blog-importer/-/blog_blog-importer-1.0.27.tgz",
-      "integrity": "sha512-/aHjY5Xx3u2GU4eSSyxvfWsbDZxWEa1Fgi+eNC5q0EMonah8vfIRYB4pg1g7gH4MpohPBvueAurPg51gi+7uDg==",
-      "dependencies": {
-        "@wix/sdk-runtime": "^0.3.22",
-        "@wix/sdk-types": "^1.12.4"
-      }
-    },
-    "node_modules/@wix/blog_categories": {
-      "version": "1.0.59",
-      "resolved": "https://registry.npmjs.org/@wix/blog_categories/-/blog_categories-1.0.59.tgz",
-      "integrity": "sha512-G+wd5j3Kt3czYSHTsplXAcYweZCrb7MA9zESvS1FpREHn9uuGBNSibF6KInAtj04xiw5QLJLELOhnLTLWxyjxg==",
-      "dependencies": {
-        "@wix/sdk-runtime": "^0.3.22",
-        "@wix/sdk-types": "^1.12.4"
-      }
-    },
-    "node_modules/@wix/blog_draft-posts": {
-      "version": "1.0.60",
-      "resolved": "https://registry.npmjs.org/@wix/blog_draft-posts/-/blog_draft-posts-1.0.60.tgz",
-      "integrity": "sha512-k2xa9a8iR03PoUNBbROr2Z8lJv9tTK+RM+80VxrStGv0M13V5tg/w+q8FKyKo29HnECgoHtV9KZSKOGf4ftEtw==",
-      "dependencies": {
-        "@wix/sdk-runtime": "^0.3.22",
-        "@wix/sdk-types": "^1.12.4"
-      }
-    },
-    "node_modules/@wix/blog_posts": {
-      "version": "1.0.69",
-      "resolved": "https://registry.npmjs.org/@wix/blog_posts/-/blog_posts-1.0.69.tgz",
-      "integrity": "sha512-agmmEVKG/ULpiu+MEqL59nEW/mtq7fAJudInv6o/qTWvVRX2bjJF3X9GqZBtQ8CwwnW20QQOzQHof0zAFOc8cg==",
-      "dependencies": {
-        "@wix/sdk-runtime": "^0.3.22",
-        "@wix/sdk-types": "^1.12.4"
-      }
-    },
-    "node_modules/@wix/blog_tags": {
-      "version": "1.0.66",
-      "resolved": "https://registry.npmjs.org/@wix/blog_tags/-/blog_tags-1.0.66.tgz",
-      "integrity": "sha512-AnI/lOmvLdBpW9MGeIUGYETp2v9rKcd7JMbbkAiw8QEvDj2fA0qZYu7RVk6LfUYb+h3ebNQyuY9HZ5ZdincZ9w==",
-      "dependencies": {
-        "@wix/sdk-runtime": "^0.3.22",
-        "@wix/sdk-types": "^1.12.4"
-      }
+      "license": "MIT"
     },
     "node_modules/@wix/cli-edge": {
       "version": "1.1.60",
-      "resolved": "https://registry.npmjs.org/@wix/cli-edge/-/cli-edge-1.1.60.tgz",
-      "integrity": "sha512-2vHYTvNnLfiJ5flOfAztG9yRuJy5bcc3YjzBYUeBCTewMujC4GH2MqMiFoX8S91ilYj9HL+lSdq97w/6U1KiwA==",
       "dev": true,
       "bin": {
         "wix": "bin/wix.cjs"
@@ -2720,8 +1338,6 @@
     },
     "node_modules/@wix/data": {
       "version": "1.0.168",
-      "resolved": "https://registry.npmjs.org/@wix/data/-/data-1.0.168.tgz",
-      "integrity": "sha512-ibleMXFp95DMrGBw9N3/Xs5ocFuYXp5eSJoPo/0a0QzpQ8Gig5GcnSV4pBjNNHHDfj6ZUPQROYm38hFkLvcHXA==",
       "dependencies": {
         "@wix/data_collections": "1.0.57",
         "@wix/data_external-database": "1.0.25",
@@ -2732,8 +1348,6 @@
     },
     "node_modules/@wix/data_collections": {
       "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/data_collections/-/data_collections-1.0.57.tgz",
-      "integrity": "sha512-NilsXsIlGxPzxXbV4Lq6u8Bi1UTcusGs2zEQBtyvF2E5TA+Od0M76vWbikAfEaTgEZrO1gEDT8UH8/iKE4O28w==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2741,8 +1355,6 @@
     },
     "node_modules/@wix/data_external-database": {
       "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@wix/data_external-database/-/data_external-database-1.0.25.tgz",
-      "integrity": "sha512-VPkuYdHuW06JnwDtZ2Y5E2K2J/HOcetp0Ea1KdfRSWoOJrOnqK36rjnrjBCNw2jWyo/0PZ6/NDKmC9WrP8wWOw==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2750,8 +1362,6 @@
     },
     "node_modules/@wix/data_external-database-connections": {
       "version": "1.0.47",
-      "resolved": "https://registry.npmjs.org/@wix/data_external-database-connections/-/data_external-database-connections-1.0.47.tgz",
-      "integrity": "sha512-PBcBEaqcD2Yg3ROCieQ+HrSPkNPOgMYufFlkahqpt7bVcoRBNIwRY040fgmNsixm9PdhH0gT4Q2tQz/Hjr381Q==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2759,8 +1369,6 @@
     },
     "node_modules/@wix/data_indexes": {
       "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/@wix/data_indexes/-/data_indexes-1.0.40.tgz",
-      "integrity": "sha512-ZdAfO75tyAMWMPw2vVRh1eTjY77LDY5P7lJTAcm4pEvPQzfe2EA5yyfD9Ejzg2TH6Lt5cQmqS9HkeC/y7ox1eQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2768,8 +1376,6 @@
     },
     "node_modules/@wix/data_items": {
       "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/data_items/-/data_items-1.0.57.tgz",
-      "integrity": "sha512-0VNrfOJ1DlE6Pfk/1RoXOTvSNnkfJg5jCKAbNbDS6UFadKErGPdN/UwcpvWpMG/3eCGvetbaXR/hb3nFrhB8gg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2777,8 +1383,6 @@
     },
     "node_modules/@wix/ecom": {
       "version": "1.0.806",
-      "resolved": "https://registry.npmjs.org/@wix/ecom/-/ecom-1.0.806.tgz",
-      "integrity": "sha512-lxw1HBnYAKSgDPxdxV+Dj1G17pP469t3pTp63n/+Dl2cwpnrjj4X3uIlGMepxH7x/LNCCiU9SBoVTKC2+Jp9cA==",
       "dependencies": {
         "@wix/ecom_abandoned-checkouts": "1.0.52",
         "@wix/ecom_additional-fees": "1.0.31",
@@ -2822,8 +1426,6 @@
     },
     "node_modules/@wix/ecom_abandoned-checkouts": {
       "version": "1.0.52",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_abandoned-checkouts/-/ecom_abandoned-checkouts-1.0.52.tgz",
-      "integrity": "sha512-jQstQqCxsY8YB/DJiaRAcpzC0tcWehH3KqyOyaFBq/9a5ZG+6ivsVpDULbX5i5C0yujw74Lq5HPXZ4Y2bjWm5A==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2831,8 +1433,6 @@
     },
     "node_modules/@wix/ecom_additional-fees": {
       "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_additional-fees/-/ecom_additional-fees-1.0.31.tgz",
-      "integrity": "sha512-9JfRF/TrEGn5filBG7dKJCAW6GDdILetjwGYUvM8BYN0id6i6RWhp8+nwhlvpnU4BJ/aXgg/rM4ywcgHRfYq5g==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2840,8 +1440,6 @@
     },
     "node_modules/@wix/ecom_back-in-stock-notifications": {
       "version": "1.0.56",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_back-in-stock-notifications/-/ecom_back-in-stock-notifications-1.0.56.tgz",
-      "integrity": "sha512-EywLnCOr1R/I6k9woTR97+17noDPxZBblwCyA1iSAL8ky5wHqu8BIKOsRIp4u57X9Sp60GiY8JK0+DvsPqVkSg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2849,8 +1447,6 @@
     },
     "node_modules/@wix/ecom_back-in-stock-settings": {
       "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_back-in-stock-settings/-/ecom_back-in-stock-settings-1.0.41.tgz",
-      "integrity": "sha512-yHLLixbkPheIdRcfcQEjGQ0cPhLXqDgnZTjU6ehQSUfNSaq8Q2ycEjml5x3tM0luoeedbCKsJdo75DPvuZtb4Q==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2858,8 +1454,6 @@
     },
     "node_modules/@wix/ecom_cart": {
       "version": "1.0.91",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_cart/-/ecom_cart-1.0.91.tgz",
-      "integrity": "sha512-SFg9FGL6VtjiSQRNxzXLE5pi0+xCUm/F3l8Z13ooT/veNmy20+JfIX/K+ypOirAR4im5ZE2UH6mKfBEIZ4NCqA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2867,8 +1461,6 @@
     },
     "node_modules/@wix/ecom_checkout": {
       "version": "1.0.99",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_checkout/-/ecom_checkout-1.0.99.tgz",
-      "integrity": "sha512-Aju0CDvW3y8lM18s8LsEAk7vzTBanUZi5iiAeNm3sbF69mPjuEeiSPAhj+7JW3OYaScDv5p/4LQRAY1g9EElgg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2876,8 +1468,6 @@
     },
     "node_modules/@wix/ecom_checkout-content": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_checkout-content/-/ecom_checkout-content-1.0.12.tgz",
-      "integrity": "sha512-C0z5aLK050z3DXdL6g2gEHy7oeG1K97+7+F8U2oAKlRmJ/6Pr7xFsTLHGBZqlRMzHIKgF5gno+Dh3INhgBBodA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2885,8 +1475,6 @@
     },
     "node_modules/@wix/ecom_checkout-settings": {
       "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_checkout-settings/-/ecom_checkout-settings-1.0.57.tgz",
-      "integrity": "sha512-npLNgxtk63x9ggx8n8WQ13S+Ggpx1rLVLgBok4UDRYS3J0ryRZenTCU52HZ37jzWlh4D9NawnGohEngfjtMyMg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2894,8 +1482,6 @@
     },
     "node_modules/@wix/ecom_checkout-templates": {
       "version": "1.0.98",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_checkout-templates/-/ecom_checkout-templates-1.0.98.tgz",
-      "integrity": "sha512-7AZ78jkBH1DNO8VYVUoWOeci9uFkJYXfI9IbtpGx7uz+0VUy+i/G/2z/vskKURbHJ7Kv2vsLJ9LMsendipmeiA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2903,8 +1489,6 @@
     },
     "node_modules/@wix/ecom_currencies": {
       "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_currencies/-/ecom_currencies-1.0.42.tgz",
-      "integrity": "sha512-6oYUjL13S06A1JPzk5nj2iNAHWGZWLEksLXZIB2EVcfF5jTOAotpQNC0lyy6B9ety0A2nBrp4oEFNmJxZDbi7A==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2912,8 +1496,6 @@
     },
     "node_modules/@wix/ecom_current-cart": {
       "version": "1.0.91",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_current-cart/-/ecom_current-cart-1.0.91.tgz",
-      "integrity": "sha512-WSYYqhtu2omqhZFgm/6ri5eOeqsbzUywMctmP+VrzRYu2+n2F7S0d/9dRQf4ozeb0qWf+f/7IaeZhnArme/IGw==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2921,8 +1503,6 @@
     },
     "node_modules/@wix/ecom_custom-triggers": {
       "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_custom-triggers/-/ecom_custom-triggers-1.0.28.tgz",
-      "integrity": "sha512-rWbZUDYp2fUBdWY9zf2ftW5C3glDSJpxqIb+se2uQXUwgUHquU8swDpPzznkDGDCxRZQpiFC2e2rU7U7fYMhHw==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2930,8 +1510,6 @@
     },
     "node_modules/@wix/ecom_delivery-profile": {
       "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_delivery-profile/-/ecom_delivery-profile-1.0.25.tgz",
-      "integrity": "sha512-1hV7lRPs+0m348s6BTsksOD4dMS5JZNFPZBX0lIZrEUHO/s8e1Um+jDK4PGGKJFCrRFZWJj0CmcopmcA5CcPHQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2939,8 +1517,6 @@
     },
     "node_modules/@wix/ecom_delivery-solutions": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_delivery-solutions/-/ecom_delivery-solutions-1.0.6.tgz",
-      "integrity": "sha512-ueShA+tgE3H6/HO2uWQjJu37VtgynKJv0xrGlAk9gUcNmAzRcOyOi3xNhgshhAQagm8u0U4jTtQwlEAkkQ8/Uw==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2948,8 +1524,6 @@
     },
     "node_modules/@wix/ecom_discount-rules": {
       "version": "1.0.58",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_discount-rules/-/ecom_discount-rules-1.0.58.tgz",
-      "integrity": "sha512-9/9POld/anEMmJJkaBO9D3SELoCUyxGkYZPUklrxcSAHJ4YPhRgFqWsoHFNAkREkT8Q+ehLtjzgNU32HAJ003g==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2957,8 +1531,6 @@
     },
     "node_modules/@wix/ecom_discounts": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_discounts/-/ecom_discounts-1.0.10.tgz",
-      "integrity": "sha512-ACfV80a1AyxjX23w0qrTiBMS2XwMTkgFSWU8ZEJqFrOL9pdEsH0VHztxMvB8Otac8G1J/APxJn5zjdJnuVuALQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2966,8 +1538,6 @@
     },
     "node_modules/@wix/ecom_discounts-custom-trigger": {
       "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_discounts-custom-trigger/-/ecom_discounts-custom-trigger-1.0.13.tgz",
-      "integrity": "sha512-Gre7MnpaDqRuQwKh9MCHbTClYSZ31FaOIkDDmrxoQX90kl05M2lEiJ6tpeBddDRZXyYKPx+FiganL7AmF1a8gQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2975,8 +1545,6 @@
     },
     "node_modules/@wix/ecom_draft-orders": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_draft-orders/-/ecom_draft-orders-1.0.34.tgz",
-      "integrity": "sha512-t2pqt0TRSKF0EvNUQTvJsqimjc7qA6QMop5q0kOhxMVYfuoMWiSKb6hjfo/Z3nCBGWy4X8G7MPIv8s0KFCFVJQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2984,8 +1552,6 @@
     },
     "node_modules/@wix/ecom_gift-vouchers": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_gift-vouchers/-/ecom_gift-vouchers-1.0.9.tgz",
-      "integrity": "sha512-pPEh5+5zlHgGOjSH6pi0Q7lKVOqeohIxy6VdRF85vLilBUxX+2BRpaFKGk5qNmwho+jjhHjDxfXYEg3u7waXOQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -2993,8 +1559,6 @@
     },
     "node_modules/@wix/ecom_gift-vouchers-provider": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_gift-vouchers-provider/-/ecom_gift-vouchers-provider-1.0.9.tgz",
-      "integrity": "sha512-Gq7Sc0oSPDXd62D7k3r85ElqXdRkwo0W6/nBucSW3pTba1rxRf6HFMzypRgiDpWyARHO5k9jd3HJ0h2XyOsG+A==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3002,8 +1566,6 @@
     },
     "node_modules/@wix/ecom_local-delivery-options": {
       "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_local-delivery-options/-/ecom_local-delivery-options-1.0.15.tgz",
-      "integrity": "sha512-qT8hcG5iEkKC9ITvK1PY/BN5GiQa/i8BpXKkoKSsTJe7pQ8QhLMDqC/6LaOUzMnIDdgG+loPNlHLTvspbMELFQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3011,8 +1573,6 @@
     },
     "node_modules/@wix/ecom_memberships": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_memberships/-/ecom_memberships-1.0.4.tgz",
-      "integrity": "sha512-DBWgZ5Xfhfle1ePAkRKmPCxJewakSiOwoUPbQ/SF8LUX+FgnA3hvuswR1Nwj2Sw7waNdjbzYKTHWHHD6fsrSVA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3020,8 +1580,6 @@
     },
     "node_modules/@wix/ecom_order-fulfillments": {
       "version": "1.0.52",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_order-fulfillments/-/ecom_order-fulfillments-1.0.52.tgz",
-      "integrity": "sha512-5QH7vWMQQMYGzsoY3paZkJ3VymPF7YUdzU734NrkvKX0ulqXYu85aXEcb9hlfiBsxNRy1BEm30B+s0bSadnlBA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3029,8 +1587,6 @@
     },
     "node_modules/@wix/ecom_order-invoices": {
       "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_order-invoices/-/ecom_order-invoices-1.0.45.tgz",
-      "integrity": "sha512-G1bj5QNG+/jPax2WR/UirfHJeEmFN15IUuFcHiGzhqV1/mCow6IK1fclSgjS3FekMuumWKD3oaDrYLUOTrAJxw==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3038,8 +1594,6 @@
     },
     "node_modules/@wix/ecom_order-payment-requests": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_order-payment-requests/-/ecom_order-payment-requests-1.0.16.tgz",
-      "integrity": "sha512-QjiLTMmIVg3BItQsXTq721w7yzHFy0fjPmRDaj+4Wvif+IpYqCZ4qrAgVdcbnYEjRXxwn5VtqbrwnwyGq+kHIg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3047,8 +1601,6 @@
     },
     "node_modules/@wix/ecom_order-transactions": {
       "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_order-transactions/-/ecom_order-transactions-1.0.73.tgz",
-      "integrity": "sha512-LQFFaCCKR28hnBysU4ergs2nsL7CYcjErzgRfw7EyLaxCAXR2w1KBU0P4+NSAXYTL56419PCQ/52mSu2SaW08w==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3056,8 +1608,6 @@
     },
     "node_modules/@wix/ecom_orders": {
       "version": "1.0.136",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_orders/-/ecom_orders-1.0.136.tgz",
-      "integrity": "sha512-HX9U6s8rxOrRwRp9Aq5G2StHqBwQAqG6Oc4afQwnq7py82zeWC3EsxJ9HVxUl1BX1gIAeO4BpSQhepHlqojBpA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3065,8 +1615,6 @@
     },
     "node_modules/@wix/ecom_orders-settings": {
       "version": "1.0.51",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_orders-settings/-/ecom_orders-settings-1.0.51.tgz",
-      "integrity": "sha512-IOtxO+axwV4yQnfS64ckQaa6dYesf79z9Gu00Hxwbx1TYz/PDYcWHhucjkUwtCD7GgsmHQtBwGhNA3I7JSFT3g==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3074,8 +1622,6 @@
     },
     "node_modules/@wix/ecom_payment-settings": {
       "version": "1.0.61",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_payment-settings/-/ecom_payment-settings-1.0.61.tgz",
-      "integrity": "sha512-ER7Wsabm99Y6b3Y0Uhyel4wRXeXcbihqpJP7vjk1hotcSvlUvJB5Uu+7ZHiEkJBFmYTaXT6DwpXllQTGajFEwg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3083,8 +1629,6 @@
     },
     "node_modules/@wix/ecom_pickup-locations": {
       "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_pickup-locations/-/ecom_pickup-locations-1.0.15.tgz",
-      "integrity": "sha512-khlQm0/MfDcUckf0h5uh+xEj+HbSjAlzxfV+XqmZrqmrro7qggH1YNOvCyvGYVyhvAtUPuQZn9AprX2a+04Lyg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3092,8 +1636,6 @@
     },
     "node_modules/@wix/ecom_recommendations": {
       "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_recommendations/-/ecom_recommendations-1.0.48.tgz",
-      "integrity": "sha512-1H3gaiMG6HaFR3ArH0vkpTSC84DCjXw6t8N9SQA6tRhHmhX2ldvoer97/NbY3vGe+3NaKzFuDybi39YBlKEFUA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3101,8 +1643,6 @@
     },
     "node_modules/@wix/ecom_recommendations-provider": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_recommendations-provider/-/ecom_recommendations-provider-1.0.6.tgz",
-      "integrity": "sha512-e8geKEChmYFOdIy+uhheHzqiKvONXTd5tgQdBDutm+oK88Te+meXaOmicdRdEqANsuQqlBt7X8FvYJ4+tKIrJw==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3110,8 +1650,6 @@
     },
     "node_modules/@wix/ecom_shipping-options": {
       "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_shipping-options/-/ecom_shipping-options-1.0.13.tgz",
-      "integrity": "sha512-7BdYyeJPlkA1Jo67PmeOlerTJBb7/IZNYnlykJ35Ke30ng6qCIKF4LRABDK98Kc37Y52bM+jz6yMMcJoRjPhnQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3119,8 +1657,6 @@
     },
     "node_modules/@wix/ecom_shipping-rates": {
       "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_shipping-rates/-/ecom_shipping-rates-1.0.48.tgz",
-      "integrity": "sha512-s9jCvlcR6jNf2w92kXZpRU6Hk6ua2PD/b8WF4xsGSJ4V7LBzV856xSLnTvksezotu+dRmMoa9jWebKi1Vb4g2w==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3128,8 +1664,6 @@
     },
     "node_modules/@wix/ecom_shippo-configurations": {
       "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_shippo-configurations/-/ecom_shippo-configurations-1.0.20.tgz",
-      "integrity": "sha512-M/LtqqAr2V0/YVrhSdtSYs6jQxaBzB+04yKBgFBKu1fPakJWaE39vS+KOgFuuTNm0+Gu8ENKX3XBnfOiSQ7w1w==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3137,8 +1671,6 @@
     },
     "node_modules/@wix/ecom_subscription-contracts": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_subscription-contracts/-/ecom_subscription-contracts-1.0.2.tgz",
-      "integrity": "sha512-FjVtFNtm+1OQ2WpespkhCy6lsWLkjI9kFPAini0EpRT4Lhr6Pq2owMJtXPkauPNTQx/Akh2rYoJZ7r5J1XqOSg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3146,8 +1678,6 @@
     },
     "node_modules/@wix/ecom_totals-calculator": {
       "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_totals-calculator/-/ecom_totals-calculator-1.0.17.tgz",
-      "integrity": "sha512-pz5cpWreBpHtIu9UGeatUG/1Znfg6IOa1n4VvcPTcgo8RrCG5HgKoa1Y6vXIgvxZKvnp+sK8gfba2EtQoty76A==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3155,8 +1685,6 @@
     },
     "node_modules/@wix/ecom_validations": {
       "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_validations/-/ecom_validations-1.0.39.tgz",
-      "integrity": "sha512-9b1tpACfOT0JU1oKtYxFxpJgR+VVc5f3aGHQ/i56CucLqhUjRSbzJDYW0yPiFLG6iS/pHyNapgkfpWJXRwXMiQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3164,8 +1692,7 @@
     },
     "node_modules/@wix/filter-builder": {
       "version": "1.0.99",
-      "resolved": "https://registry.npmjs.org/@wix/filter-builder/-/filter-builder-1.0.99.tgz",
-      "integrity": "sha512-uYf9isvx0Mck/BR1BynijBUrpPvdxJyCgr596Y627HpCS7+klnKbjvocGsgOeaBwTzqUUz832SCjMrq/xbYjuA==",
+      "license": "UNLICENSED",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "kind-of": "~5.1.0",
@@ -3174,8 +1701,6 @@
     },
     "node_modules/@wix/identity": {
       "version": "1.0.113",
-      "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.113.tgz",
-      "integrity": "sha512-om7fJxG25Om8ZjK1zen5VD8wznXTy2phOSwGUrlTsWzmGvalmUoCKnEjPR7mzVrHUElB/clXCJUfFX2gUp6QQg==",
       "dependencies": {
         "@wix/identity_authentication": "1.0.34",
         "@wix/identity_oauth": "1.0.17",
@@ -3185,8 +1710,6 @@
     },
     "node_modules/@wix/identity_authentication": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@wix/identity_authentication/-/identity_authentication-1.0.34.tgz",
-      "integrity": "sha512-JKkLlH/fCkbAJwQPLcjIGa5lYdW+uiLtVhZXkRKT38srQnYKs2xjIxkpV/Z3aotH/uZ22bCMLxu9FAAMl/LgmA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3194,8 +1717,6 @@
     },
     "node_modules/@wix/identity_oauth": {
       "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@wix/identity_oauth/-/identity_oauth-1.0.17.tgz",
-      "integrity": "sha512-S3xrdiRysz34CsZ/bUyPELyA51PBeUshGnekGWLSiIVYlbDot8C7GTQa2x0s4/CcmDJCZvLqdNCiu3SOZyOxCA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3203,8 +1724,6 @@
     },
     "node_modules/@wix/identity_recovery": {
       "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@wix/identity_recovery/-/identity_recovery-1.0.24.tgz",
-      "integrity": "sha512-9zAAc6A0rSIXD4bMFhd7hjn0rbkJlEKr7vCoQ+qj/keuVQqNqQSKtu3xvDXJjPgAJDbLyd4RJblM8UAFfFKc+w==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3212,8 +1731,6 @@
     },
     "node_modules/@wix/identity_verification": {
       "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@wix/identity_verification/-/identity_verification-1.0.23.tgz",
-      "integrity": "sha512-n8v+/KauwhbCAyPdDR8nCZmzkc/9XW2YsMUFCmh8Xa8GiRbh1QJLeTTl/MIUBBGdFdGxGfXjXmbh3ShxHkmlEg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3221,8 +1738,7 @@
     },
     "node_modules/@wix/image-kit": {
       "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.102.0.tgz",
-      "integrity": "sha512-7d6OwDzUHIeBOi2yMQefJMQatCXLjXtKAhq82D/GHBEl+77utjeq8bywk8OFQQqaTXrmXZrtlO7v7OmdDEnGgw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "tslib": "^2.8.1"
@@ -3230,16 +1746,14 @@
     },
     "node_modules/@wix/metro-public-utils": {
       "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@wix/metro-public-utils/-/metro-public-utils-1.0.38.tgz",
-      "integrity": "sha512-tLkWVWYmFmTbRp4QwgQnMQ+7JHfbgRNY/Hb7sS6Lki0KD/577kFBcDuPOYPxIZSMeOFlOKD9Rp4WqLGbzP4pfQ==",
+      "license": "UNLICENSED",
       "dependencies": {
         "@babel/runtime": "^7.0.0"
       }
     },
     "node_modules/@wix/metro-runtime": {
       "version": "1.1913.0",
-      "resolved": "https://registry.npmjs.org/@wix/metro-runtime/-/metro-runtime-1.1913.0.tgz",
-      "integrity": "sha512-q6JzJXNPROC8v52gUiXMR57TC7mMBaFPsdQapsGLtDgkzerT1ijuWEWZ/WQdO0DBsclPrAQHk0Yc4VdfBYeAlw==",
+      "license": "UNLICENSED",
       "dependencies": {
         "@wix/metro-public-utils": "1.0.38",
         "@wix/motion-edm-autogen-p13n": "1.0.93",
@@ -3252,13 +1766,11 @@
     },
     "node_modules/@wix/monitoring-types": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.5.0.tgz",
-      "integrity": "sha512-Nq5Rcd9TMAUZygTuCuwSqhu/MDm8fXFbgDptQTsabDHPPEZyCdmloq70XqrD7TvzGntmh5PR4Xda/M8ITwfszA=="
+      "license": "UNLICENSED"
     },
     "node_modules/@wix/motion-edm-autogen-common": {
       "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-common/-/motion-edm-autogen-common-1.53.0.tgz",
-      "integrity": "sha512-gr3r+chXH9kGQCGtx0ATfLT2AVo4Ugdh3XBcO0/tCXiUlgChYYVyf56mnESqeaHs7oF1TR7JT5WpIjMfXHzrCQ==",
+      "license": "UNLICENSED",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@wix/motion-edm-autogen-types": "1.0.41",
@@ -3268,8 +1780,6 @@
     },
     "node_modules/@wix/motion-edm-autogen-p13n": {
       "version": "1.0.93",
-      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-p13n/-/motion-edm-autogen-p13n-1.0.93.tgz",
-      "integrity": "sha512-HeM+dagv6MBNhsNTHVo/uBNHlv8/IgVVXYC6cYxAzoMivZYLYd2B0Hc2ZGZPzsCrF3CThqbxokVZ9BiwcXyNGQ==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@wix/motion-edm-autogen-types": "1.0.41",
@@ -3279,8 +1789,6 @@
     },
     "node_modules/@wix/motion-edm-autogen-query-wrapper": {
       "version": "1.0.134",
-      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-query-wrapper/-/motion-edm-autogen-query-wrapper-1.0.134.tgz",
-      "integrity": "sha512-5KiLakWCFTODcCOT8Qfy4TiJnS1KKcmdklNujHHqnpkZbLsXowS0aPgCuz0ciqTuWuk6fsUKNkgkxL1Q2F3i+w==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@wix/filter-builder": "^1.0.99",
@@ -3293,8 +1801,7 @@
     },
     "node_modules/@wix/motion-edm-autogen-transformations": {
       "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-transformations/-/motion-edm-autogen-transformations-1.63.0.tgz",
-      "integrity": "sha512-5Puu6gmjXy0EpcOb3gdw22y5jfcjXDWmppI/4PvlReyVC/s8EsksemxqeAoAXnXCiOErFHOc7wcFuRthx3w3yQ==",
+      "license": "UNLICENSED",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@rushstack/eslint-patch": "^1.1.0",
@@ -3311,8 +1818,7 @@
     },
     "node_modules/@wix/motion-edm-autogen-transformations-core": {
       "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-transformations-core/-/motion-edm-autogen-transformations-core-1.57.0.tgz",
-      "integrity": "sha512-iBbx8exYHbxCHwzS3lZ6zJ2dWQ9Z4K2M+bvplXjxulnrefwgIkhoKfLV2hwrGQgfJtYEr1mDh4HyMeOi3wOgdA==",
+      "license": "UNLICENSED",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@rushstack/eslint-patch": "^1.1.0",
@@ -3325,22 +1831,16 @@
       }
     },
     "node_modules/@wix/motion-edm-autogen-types": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-types/-/motion-edm-autogen-types-1.0.41.tgz",
-      "integrity": "sha512-W/KXPlJ6vNmxVNYAmoTzJwsryNlXgIUxfeopgjkUMfgouhlLYKw5sbJKF7M9/DM7CXXQF0WYKNZyXsdvW7HspA=="
+      "version": "1.0.41"
     },
     "node_modules/@wix/redirects": {
       "version": "1.0.70",
-      "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.70.tgz",
-      "integrity": "sha512-l4pU2h1G+H+vHVTtDw7MtjwFTnl4m8/IHHo7DXDZwvwTjzgad9fS7EUMZ1SrReSaDIqXCTLYB/HoKuF1Q0LNIw==",
       "dependencies": {
         "@wix/redirects_redirects": "1.0.39"
       }
     },
     "node_modules/@wix/redirects_redirects": {
       "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@wix/redirects_redirects/-/redirects_redirects-1.0.39.tgz",
-      "integrity": "sha512-cOO5oAaBVjeDANnz3Rf2tkn8lOJAFu6b5cF0T0yV2FXOsYgS6w8K+ai6JBCghCmZRelR0OL6Ooy3imsbAUlRlw==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3348,8 +1848,7 @@
     },
     "node_modules/@wix/sdk": {
       "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.15.9.tgz",
-      "integrity": "sha512-jBCN0r8cQIX8nXKj6bM3BEDmXBAjj7u7jwR5TaaC2zsEG6KVM2KKBi8/8VpwxRipRok1MY893a51rCi/HbsnCw==",
+      "license": "MIT",
       "dependencies": {
         "@wix/identity": "^1.0.104",
         "@wix/image-kit": "^1.102.0",
@@ -3366,13 +1865,11 @@
     },
     "node_modules/@wix/sdk-context": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
-      "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A=="
+      "license": "UNLICENSED"
     },
     "node_modules/@wix/sdk-runtime": {
       "version": "0.3.32",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.32.tgz",
-      "integrity": "sha512-a/uJCWDKc/sAaoP60LI5qHDXYM7265QAVByPI+xfJfp8dlkwAZxz1vhfSljdCXyus7Ygkd2kiPvi1zevWfYGDg==",
+      "license": "MIT",
       "dependencies": {
         "@wix/sdk-context": "^0.0.1",
         "@wix/sdk-types": "^1.13.3"
@@ -3380,16 +1877,14 @@
     },
     "node_modules/@wix/sdk-types": {
       "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.13.3.tgz",
-      "integrity": "sha512-5Ch6f1aFp9s/NDrx3xme5okk77NZpv2UYzJIjK4QyY5IzqcksYJBgZapsTfT12B3ROHiXamjqQRCncuY80AEtg==",
+      "license": "MIT",
       "dependencies": {
         "@wix/monitoring-types": "^0.5.0"
       }
     },
     "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.31.tgz",
-      "integrity": "sha512-/yhU2LIgpM2fwcjXXWGqnSAQ6XPSbni3SB9/B9j05aqPt0E5y86KqtvgbdDydmPB3bcVD12CZVjto2+MKCPnkA==",
+      "license": "MIT",
       "dependencies": {
         "@wix/sdk-context": "^0.0.1",
         "@wix/sdk-types": "^1.13.2"
@@ -3397,8 +1892,6 @@
     },
     "node_modules/@wix/stores": {
       "version": "1.0.280",
-      "resolved": "https://registry.npmjs.org/@wix/stores/-/stores-1.0.280.tgz",
-      "integrity": "sha512-UtRhEPcAqgWr3zyeo4WTtFkbBDfjpynvFoBvHBAQORrJOMjQYLQcOgWp9mHs9qGp+657FwSjBED3R5c9b/0IZg==",
       "dependencies": {
         "@wix/stores_brands-v-3": "1.0.18",
         "@wix/stores_catalog-versioning": "1.0.10",
@@ -3417,8 +1910,6 @@
     },
     "node_modules/@wix/stores_brands-v-3": {
       "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@wix/stores_brands-v-3/-/stores_brands-v-3-1.0.18.tgz",
-      "integrity": "sha512-ZNQAMmz0sWFbbEKFJDAVlZARgAHBfXnrvMHJUsxjvLvECvBLbvMQ9xLLI2P4syCYYrQvFqotFVW7p748PhvAnA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3426,8 +1917,6 @@
     },
     "node_modules/@wix/stores_catalog-versioning": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@wix/stores_catalog-versioning/-/stores_catalog-versioning-1.0.10.tgz",
-      "integrity": "sha512-T/RXUAyN3vnNtQQFTWA89y7pIGb6nk+rE0Jx3SvC4hMB/vvme2slBxEw4yyP1bm0vXi8/5yan3j8NuQ6zvXgIA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3435,8 +1924,6 @@
     },
     "node_modules/@wix/stores_collections": {
       "version": "1.0.44",
-      "resolved": "https://registry.npmjs.org/@wix/stores_collections/-/stores_collections-1.0.44.tgz",
-      "integrity": "sha512-q3uYDiGk/UaFCOjyDKSl7e+1zNVuMsj7PaFknCIczY9gLqxgBLeuc/0ygks7sK4CFmW2t6dOc1+wtUyz6cpvrw==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3444,8 +1931,6 @@
     },
     "node_modules/@wix/stores_customizations-v-3": {
       "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@wix/stores_customizations-v-3/-/stores_customizations-v-3-1.0.19.tgz",
-      "integrity": "sha512-JBaH8u7Sx7ThR5LrCaO2x2LvNr868Aj4XW3FXswggLslqks/1IUtDlgb6z/lqPDMXwPNoobTkmyVweyIT1QdSg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3453,8 +1938,6 @@
     },
     "node_modules/@wix/stores_info-sections-v-3": {
       "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@wix/stores_info-sections-v-3/-/stores_info-sections-v-3-1.0.21.tgz",
-      "integrity": "sha512-Gmk7pHB0dT5QJR0CXrHqLbovyK4IdoQvpBhDHOF6gtD+5fhhx1zxGJPkQO5CvpZY8nMNSB1eL5Y7ieHaea8tug==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3462,8 +1945,6 @@
     },
     "node_modules/@wix/stores_inventory": {
       "version": "1.0.56",
-      "resolved": "https://registry.npmjs.org/@wix/stores_inventory/-/stores_inventory-1.0.56.tgz",
-      "integrity": "sha512-2KlNBi6wR8Ju2gdaCV0RigJ+fuqndtl7TXxfuzUPKQ33gopSSCNAa9GthjcwOZPlPNUOwB4YjvIQU3gYT/ewlg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3471,8 +1952,6 @@
     },
     "node_modules/@wix/stores_inventory-items-v-3": {
       "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@wix/stores_inventory-items-v-3/-/stores_inventory-items-v-3-1.0.23.tgz",
-      "integrity": "sha512-6gnDyFQwnaTwrbPXM24ZtsvQjMHsTuKhaluaD25h2wFfWmixyWDDwpGmVMbtvL0O7jvzPGaEm+dxNRX+Szir+Q==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3480,8 +1959,6 @@
     },
     "node_modules/@wix/stores_products": {
       "version": "1.0.81",
-      "resolved": "https://registry.npmjs.org/@wix/stores_products/-/stores_products-1.0.81.tgz",
-      "integrity": "sha512-J8a/sg3uE3t2kNmuyo25gqjgXQt/e5LrQO8VCDe3ZqteMl4RWKRVovHBDqVoZFqVn/0IDf+MBVeWx8yeMMpKlg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3489,8 +1966,6 @@
     },
     "node_modules/@wix/stores_products-v-3": {
       "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@wix/stores_products-v-3/-/stores_products-v-3-1.0.63.tgz",
-      "integrity": "sha512-i8KnebOcMOF5odO8syAWjFt3pQfPz2qs1zs4GOHe70eRN/3hqrBWTJ+Y5RFiAhiSZ3xEFShnOHx/AWJXtI4Dxg==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3498,8 +1973,6 @@
     },
     "node_modules/@wix/stores_ribbons-v-3": {
       "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@wix/stores_ribbons-v-3/-/stores_ribbons-v-3-1.0.19.tgz",
-      "integrity": "sha512-f6d7qjK2YNkC85g52/WuQ86zhfGkuUhTRfsxBLnkzXoANtraVLO0UiZmLXxSOTHDt9OXR2+RawUKoMeV/fg1hA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3507,8 +1980,6 @@
     },
     "node_modules/@wix/stores_stores-locations-v-3": {
       "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@wix/stores_stores-locations-v-3/-/stores_stores-locations-v-3-1.0.20.tgz",
-      "integrity": "sha512-vGAFi5L0Tumn/MZOpab+5IO/n0MmcJFhr6kMOsAUdwxOEoDBwld90J6pcYm3ihj59jx3LPfdeI5ohsdc+q7RDA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3516,8 +1987,6 @@
     },
     "node_modules/@wix/stores_subscription-options": {
       "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@wix/stores_subscription-options/-/stores_subscription-options-1.0.43.tgz",
-      "integrity": "sha512-T/VVYo0sGCVjvg6/Hq+zZx8CdWQrkFHMTmIjLpWKfb3f+6hBBmOpMunNr3CJGC3PLMH0WLnYHJMa9JSszT7FpA==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3525,8 +1994,6 @@
     },
     "node_modules/@wix/stores_wishlist": {
       "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@wix/stores_wishlist/-/stores_wishlist-1.0.36.tgz",
-      "integrity": "sha512-ecVLLVApxTvH3qHYqW7vUk1jXioUVs99P4Aj648XxQSyNPZMsRdHwYPZYoyC484z83OMSJPPqJbW+x89oGQjLQ==",
       "dependencies": {
         "@wix/sdk-runtime": "^0.3.22",
         "@wix/sdk-types": "^1.12.4"
@@ -3534,8 +2001,7 @@
     },
     "node_modules/acorn": {
       "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3545,8 +2011,7 @@
     },
     "node_modules/ajv": {
       "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3560,29 +2025,25 @@
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.1.0"
       }
     },
     "node_modules/ansi-align/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-align/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/ansi-align/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3594,8 +2055,7 @@
     },
     "node_modules/ansi-align/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3605,8 +2065,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3616,8 +2075,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3627,13 +2085,11 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3644,8 +2100,7 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -3655,26 +2110,22 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/array-iterate": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
-      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3682,8 +2133,7 @@
     },
     "node_modules/astro": {
       "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.2.4.tgz",
-      "integrity": "sha512-zTWiOyRIy+cKzdjG4mvb5gJ8/Gy0z1s9nAZVirlzpYXd8j5LORlKPywEalNU+Q+nssG2QadBTxXCmAjhKYB93Q==",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.10.3",
         "@astrojs/internal-helpers": "0.5.1",
@@ -3767,8 +2217,6 @@
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
       "funding": [
         {
           "type": "opencollective",
@@ -3783,6 +2231,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "browserslist": "^4.23.3",
         "caniuse-lite": "^1.0.30001646",
@@ -3803,16 +2252,14 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/bail": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3820,18 +2267,15 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "license": "MIT"
     },
     "node_modules/base-64": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -3841,8 +2285,7 @@
     },
     "node_modules/boxen": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
-      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "license": "MIT",
       "dependencies": {
         "ansi-align": "^3.0.1",
         "camelcase": "^8.0.0",
@@ -3862,16 +2305,14 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -3881,8 +2322,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3897,6 +2336,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3912,8 +2352,7 @@
     },
     "node_modules/camelcase": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
-      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -3923,16 +2362,13 @@
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001697",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
-      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3946,12 +2382,12 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3959,8 +2395,7 @@
     },
     "node_modules/chalk": {
       "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3970,8 +2405,7 @@
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3979,8 +2413,7 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3988,8 +2421,7 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3997,8 +2429,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -4020,22 +2451,20 @@
     },
     "node_modules/ci-info": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
-      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4045,8 +2474,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -4058,16 +2486,14 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cliui/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4080,13 +2506,11 @@
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4098,8 +2522,7 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4109,8 +2532,7 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4125,16 +2547,14 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/color": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1",
@@ -4146,8 +2566,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4157,13 +2576,11 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "license": "MIT"
     },
     "node_modules/color-string": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "color-name": "^1.0.0",
@@ -4172,8 +2589,7 @@
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4181,29 +2597,25 @@
     },
     "node_modules/commander": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
-      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="
+      "license": "ISC"
     },
     "node_modules/consola": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
-      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
+      "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/constant-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -4212,26 +2624,22 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-es": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
-      "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4243,16 +2651,14 @@
     },
     "node_modules/crossws": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.3.tgz",
-      "integrity": "sha512-/71DJT3xJlqSnBr83uGJesmVHSzZEvgxHt/fIKxBAAngqMHmnBWQNxCphVxxJ2XL3xleu5+hJD6IQ3TglBedcw==",
+      "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -4262,14 +2668,12 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4284,8 +2688,7 @@
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
       },
@@ -4296,34 +2699,29 @@
     },
     "node_modules/deep-for-each": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/deep-for-each/-/deep-for-each-3.0.0.tgz",
-      "integrity": "sha512-pPN+0f8jlnNP+z90qqOdxGghJU5XM6oBDhvAR+qdQzjCg5pk/7VPPvKK1GqoXEFkHza6ZS+Otzzvmr0g3VUaKw==",
+      "license": "MIT",
       "dependencies": {
         "lodash.isplainobject": "^4.0.6"
       }
     },
     "node_modules/defu": {
       "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+      "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/destr": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.3.tgz",
-      "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=8"
@@ -4331,8 +2729,7 @@
     },
     "node_modules/deterministic-object-hash": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
-      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+      "license": "MIT",
       "dependencies": {
         "base-64": "^1.0.0"
       },
@@ -4342,13 +2739,11 @@
     },
     "node_modules/devalue": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
-      "integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw=="
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
       },
@@ -4359,44 +2754,43 @@
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+      "license": "Apache-2.0"
     },
     "node_modules/diff": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+      "license": "MIT"
     },
     "node_modules/dset": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.92",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.92.tgz",
-      "integrity": "sha512-BeHgmNobs05N1HMmMZ7YIuHfYBGlq/UmvlsTgg+fsbFs9xVMj+xJHFg19GN04+9Q+r8Xnh9LXqaYIyEWElnNgQ=="
+      "license": "ISC"
     },
     "node_modules/emmet": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
-      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
       "dependencies": {
         "@emmetio/abbreviation": "^2.3.3",
         "@emmetio/css-abbreviation": "^2.1.8"
@@ -4404,18 +2798,15 @@
     },
     "node_modules/emoji-regex": {
       "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="
+      "license": "MIT"
     },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -4425,14 +2816,12 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ=="
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4469,16 +2858,14 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4488,13 +2875,11 @@
     },
     "node_modules/esm-resolve": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/esm-resolve/-/esm-resolve-1.0.11.tgz",
-      "integrity": "sha512-LxF0wfUQm3ldUDHkkV2MIbvvY0TgzIpJ420jHSV1Dm+IlplBEWiJTKWM61GtxUfvjV6iD4OtTYFGAGM2uuIUWg=="
+      "license": "Apache-2.0"
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -4505,31 +2890,26 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -4543,8 +2923,6 @@
     },
     "node_modules/fast-uri": {
       "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
       "funding": [
         {
           "type": "github",
@@ -4554,12 +2932,11 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
-      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
       "funding": [
         {
           "type": "github",
@@ -4570,6 +2947,7 @@
           "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -4579,16 +2957,14 @@
     },
     "node_modules/fastq": {
       "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -4598,8 +2974,7 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -4610,8 +2985,7 @@
     },
     "node_modules/find-up-simple": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
-      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4621,8 +2995,7 @@
     },
     "node_modules/find-yarn-workspace-root2": {
       "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz",
-      "integrity": "sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2",
         "pkg-dir": "^4.2.0"
@@ -4630,16 +3003,14 @@
     },
     "node_modules/flattie": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
-      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -4653,8 +3024,7 @@
     },
     "node_modules/fraction.js": {
       "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       },
@@ -4665,9 +3035,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4678,32 +3046,28 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4713,13 +3077,11 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
+      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -4737,8 +3099,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4748,16 +3109,14 @@
     },
     "node_modules/globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/globby": {
       "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
-      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^2.1.0",
         "fast-glob": "^3.3.2",
@@ -4775,13 +3134,11 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "license": "ISC"
     },
     "node_modules/graphql": {
       "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -4789,8 +3146,7 @@
     },
     "node_modules/h3": {
       "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.14.0.tgz",
-      "integrity": "sha512-ao22eiONdgelqcnknw0iD645qW0s9NnrJHr5OBz4WOMdBdycfSas1EQf1wXRsm+PcB2Yoj43pjBPwqIpJQTeWg==",
+      "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
         "crossws": "^0.3.2",
@@ -4806,8 +3162,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4817,8 +3172,7 @@
     },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.1.0",
@@ -4834,8 +3188,7 @@
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.2.tgz",
-      "integrity": "sha512-SfMzfdAi/zAoZ1KkFEyyeXBn7u/ShQrfd675ZEE9M3qj+PMFX05xubzRyF76CCSJu8au9jgVxDV1+okFvgZU4A==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -4853,8 +3206,7 @@
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -4865,8 +3217,7 @@
     },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -4877,8 +3228,7 @@
     },
     "node_modules/hast-util-raw": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
-      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -4901,8 +3251,7 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.4.tgz",
-      "integrity": "sha512-wxQzXtdbhiwGAUKrnQJXlOPmHnEehzphwkK7aluUPQ+lEc1xefC8pblMgpp2w5ldBTEfveRIrADcrhGIWrlTDA==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -4923,8 +3272,7 @@
     },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
-      "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -4941,8 +3289,7 @@
     },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -4956,8 +3303,7 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -4968,8 +3314,7 @@
     },
     "node_modules/hastscript": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
-      "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -4984,13 +3329,11 @@
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
+      "license": "MIT"
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4998,26 +3341,22 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5025,22 +3364,19 @@
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
-      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -5050,8 +3386,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -5064,8 +3399,7 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -5078,24 +3412,21 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -5105,8 +3436,7 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -5122,16 +3452,14 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -5141,8 +3469,7 @@
     },
     "node_modules/is-wsl": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -5155,13 +3482,11 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -5174,34 +3499,29 @@
     },
     "node_modules/jiti": {
       "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
       }
     },
     "node_modules/jose": {
       "version": "5.9.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
-      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-base64": {
       "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5211,8 +3531,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -5222,13 +3541,11 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5238,37 +3555,32 @@
     },
     "node_modules/jsonc-parser": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
-      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
+      "license": "MIT"
     },
     "node_modules/jsonpath-plus": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-5.1.0.tgz",
-      "integrity": "sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/kind-of": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       },
@@ -5278,13 +3590,11 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "license": "MIT"
     },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz",
-      "integrity": "sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.5",
         "js-yaml": "^3.13.0",
@@ -5297,16 +3607,14 @@
     },
     "node_modules/load-yaml-file/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/load-yaml-file/node_modules/js-yaml": {
       "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5317,8 +3625,7 @@
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -5328,33 +3635,27 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "license": "MIT"
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
-      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q=="
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5362,29 +3663,25 @@
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/magicast": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
@@ -5393,8 +3690,7 @@
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5402,8 +3698,7 @@
     },
     "node_modules/mdast-util-definitions": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
-      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -5416,8 +3711,7 @@
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "escape-string-regexp": "^5.0.0",
@@ -5431,8 +3725,7 @@
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -5454,8 +3747,7 @@
     },
     "node_modules/mdast-util-gfm": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
-      "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+      "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-gfm-autolink-literal": "^2.0.0",
@@ -5472,8 +3764,7 @@
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "ccount": "^2.0.0",
@@ -5488,8 +3779,7 @@
     },
     "node_modules/mdast-util-gfm-footnote": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
-      "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "devlop": "^1.1.0",
@@ -5504,8 +3794,7 @@
     },
     "node_modules/mdast-util-gfm-strikethrough": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -5518,8 +3807,7 @@
     },
     "node_modules/mdast-util-gfm-table": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
@@ -5534,8 +3822,7 @@
     },
     "node_modules/mdast-util-gfm-task-list-item": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
@@ -5549,8 +3836,7 @@
     },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
@@ -5562,8 +3848,7 @@
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -5582,8 +3867,7 @@
     },
     "node_modules/mdast-util-to-markdown": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -5602,8 +3886,7 @@
     },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
       },
@@ -5614,16 +3897,13 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micromark": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
-      "integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5634,6 +3914,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -5656,8 +3937,6 @@
     },
     "node_modules/micromark-core-commonmark": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
-      "integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5668,6 +3947,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "devlop": "^1.0.0",
@@ -5689,8 +3969,7 @@
     },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
         "micromark-extension-gfm-footnote": "^2.0.0",
@@ -5708,8 +3987,7 @@
     },
     "node_modules/micromark-extension-gfm-autolink-literal": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-sanitize-uri": "^2.0.0",
@@ -5723,8 +4001,7 @@
     },
     "node_modules/micromark-extension-gfm-footnote": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-core-commonmark": "^2.0.0",
@@ -5742,8 +4019,7 @@
     },
     "node_modules/micromark-extension-gfm-strikethrough": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",
@@ -5759,8 +4035,7 @@
     },
     "node_modules/micromark-extension-gfm-table": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-factory-space": "^2.0.0",
@@ -5775,8 +4050,7 @@
     },
     "node_modules/micromark-extension-gfm-tagfilter": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
       },
@@ -5787,8 +4061,7 @@
     },
     "node_modules/micromark-extension-gfm-task-list-item": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-factory-space": "^2.0.0",
@@ -5803,8 +4076,6 @@
     },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5815,6 +4086,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -5823,8 +4095,6 @@
     },
     "node_modules/micromark-factory-label": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5835,6 +4105,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-character": "^2.0.0",
@@ -5844,8 +4115,6 @@
     },
     "node_modules/micromark-factory-space": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5856,6 +4125,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -5863,8 +4133,6 @@
     },
     "node_modules/micromark-factory-title": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5875,6 +4143,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
@@ -5884,8 +4153,6 @@
     },
     "node_modules/micromark-factory-whitespace": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5896,6 +4163,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
@@ -5905,8 +4173,6 @@
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5917,6 +4183,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -5924,8 +4191,6 @@
     },
     "node_modules/micromark-util-chunked": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5936,14 +4201,13 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
     },
     "node_modules/micromark-util-classify-character": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5954,6 +4218,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -5962,8 +4227,6 @@
     },
     "node_modules/micromark-util-combine-extensions": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5974,6 +4237,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-chunked": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -5981,8 +4245,6 @@
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5993,14 +4255,13 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
     },
     "node_modules/micromark-util-decode-string": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6011,6 +4272,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^2.0.0",
@@ -6020,38 +4282,6 @@
     },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/micromark-util-html-tag-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6062,14 +4292,41 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
     },
     "node_modules/micromark-util-resolve-all": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6080,14 +4337,13 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
       }
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6098,6 +4354,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-encode": "^2.0.0",
@@ -6106,8 +4363,6 @@
     },
     "node_modules/micromark-util-subtokenize": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.4.tgz",
-      "integrity": "sha512-N6hXjrin2GTJDe3MVjf5FuXpm12PGm80BrUAeub9XFXca8JZbP+oIwY4LJSVwFUCL1IPm/WwSVUN7goFHmSGGQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6118,6 +4373,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",
@@ -6127,8 +4383,6 @@
     },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6138,12 +4392,11 @@
           "type": "OpenCollective",
           "url": "https://opencollective.com/unified"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
-      "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6153,12 +4406,12 @@
           "type": "OpenCollective",
           "url": "https://opencollective.com/unified"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -6169,8 +4422,7 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6180,8 +4432,7 @@
     },
     "node_modules/mime": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -6191,8 +4442,7 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6205,34 +4455,29 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
-      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -6241,14 +4486,13 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6258,16 +4502,14 @@
     },
     "node_modules/neotraverse": {
       "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/nlcst-to-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
-      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0"
       },
@@ -6278,8 +4520,7 @@
     },
     "node_modules/no-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -6287,50 +4528,43 @@
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
-      "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ=="
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/ofetch": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
-      "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
+      "license": "MIT",
       "dependencies": {
         "destr": "^2.0.3",
         "node-fetch-native": "^1.6.4",
@@ -6339,13 +4573,11 @@
     },
     "node_modules/ohash": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
-      "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g=="
+      "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
-      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",
         "regex": "^5.1.1",
@@ -6354,8 +4586,7 @@
     },
     "node_modules/p-limit": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.1.1"
       },
@@ -6368,8 +4599,7 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -6379,8 +4609,7 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -6393,8 +4622,7 @@
     },
     "node_modules/p-queue": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
-      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^6.1.2"
@@ -6408,8 +4636,7 @@
     },
     "node_modules/p-timeout": {
       "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -6419,21 +4646,18 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parse-latin": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
-      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
         "@types/unist": "^3.0.0",
@@ -6449,8 +4673,7 @@
     },
     "node_modules/parse5": {
       "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "license": "MIT",
       "dependencies": {
         "entities": "^4.5.0"
       },
@@ -6460,34 +4683,29 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -6501,8 +4719,7 @@
     },
     "node_modules/path-type": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
-      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6512,18 +4729,15 @@
     },
     "node_modules/pathe": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6533,24 +4747,21 @@
     },
     "node_modules/pify": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/pirates": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -6560,8 +4771,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6576,6 +4785,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -6587,8 +4797,7 @@
     },
     "node_modules/postcss-import": {
       "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -6603,8 +4812,7 @@
     },
     "node_modules/postcss-js": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -6621,8 +4829,6 @@
     },
     "node_modules/postcss-load-config": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6633,6 +4839,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "lilconfig": "^3.0.0",
         "yaml": "^2.3.4"
@@ -6655,8 +4862,6 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6667,6 +4872,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^6.1.1"
       },
@@ -6679,8 +4885,7 @@
     },
     "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -6691,8 +4896,7 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -6703,13 +4907,11 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "license": "MIT"
     },
     "node_modules/preferred-pm": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-4.1.0.tgz",
-      "integrity": "sha512-cNKMVcSvE3hZBRukdRsvPtlUaM2fYLFbIvBz620XaDA5SjHsCRsAjNE2baI90Hh7QvJIjCHJYnpPtyqJ1/kOjQ==",
+      "license": "MIT",
       "dependencies": {
         "find-up-simple": "^1.0.0",
         "find-yarn-workspace-root2": "1.2.16",
@@ -6721,8 +4923,7 @@
     },
     "node_modules/prettier": {
       "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "license": "MIT",
       "optional": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -6736,16 +4937,14 @@
     },
     "node_modules/prismjs": {
       "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -6756,16 +4955,14 @@
     },
     "node_modules/prompts/node_modules/kleur": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/property-information": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
-      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6773,17 +4970,13 @@
     },
     "node_modules/querystring": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "funding": [
         {
           "type": "github",
@@ -6797,17 +4990,16 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/radix3": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
-      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6815,8 +5007,7 @@
     },
     "node_modules/react-dom": {
       "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
@@ -6827,32 +5018,28 @@
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
       }
     },
     "node_modules/read-cache/node_modules/pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -6862,8 +5049,7 @@
     },
     "node_modules/readdirp/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6873,21 +5059,18 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "license": "MIT"
     },
     "node_modules/regex": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
-      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
+      "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
       }
     },
     "node_modules/regex-recursion": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
-      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
+      "license": "MIT",
       "dependencies": {
         "regex": "^5.1.1",
         "regex-utilities": "^2.3.0"
@@ -6895,13 +5078,11 @@
     },
     "node_modules/regex-utilities": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="
+      "license": "MIT"
     },
     "node_modules/rehype": {
       "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
-      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "rehype-parse": "^9.0.0",
@@ -6915,8 +5096,7 @@
     },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-from-html": "^2.0.0",
@@ -6929,8 +5109,7 @@
     },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
-      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
@@ -6943,8 +5122,7 @@
     },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
-      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-html": "^9.0.0",
@@ -6957,8 +5135,7 @@
     },
     "node_modules/remark-gfm": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz",
-      "integrity": "sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-gfm": "^3.0.0",
@@ -6974,8 +5151,7 @@
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -6989,8 +5165,7 @@
     },
     "node_modules/remark-rehype": {
       "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.1.tgz",
-      "integrity": "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -7005,8 +5180,7 @@
     },
     "node_modules/remark-smartypants": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
-      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+      "license": "MIT",
       "dependencies": {
         "retext": "^9.0.0",
         "retext-smartypants": "^6.0.0",
@@ -7019,8 +5193,7 @@
     },
     "node_modules/remark-stringify": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-to-markdown": "^2.0.0",
@@ -7033,29 +5206,25 @@
     },
     "node_modules/request-light": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
-      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
       "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -7073,8 +5242,7 @@
     },
     "node_modules/retext": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
-      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+      "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
         "retext-latin": "^4.0.0",
@@ -7088,8 +5256,7 @@
     },
     "node_modules/retext-latin": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
-      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+      "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
         "parse-latin": "^7.0.0",
@@ -7102,8 +5269,7 @@
     },
     "node_modules/retext-smartypants": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
-      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
         "nlcst-to-string": "^4.0.0",
@@ -7116,8 +5282,7 @@
     },
     "node_modules/retext-stringify": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
-      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+      "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
         "nlcst-to-string": "^4.0.0",
@@ -7130,8 +5295,7 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -7139,8 +5303,7 @@
     },
     "node_modules/rollup": {
       "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.0.tgz",
-      "integrity": "sha512-+4C/cgJ9w6sudisA0nZz0+O7lTP9a3CzNLsoDwaRumM8QHwghUsu6tqHXiTmNUp/rqNiM14++7dkzHDyCRs0Jg==",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -7176,8 +5339,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "funding": [
         {
           "type": "github",
@@ -7192,25 +5353,23 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/sax": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+      "license": "ISC"
     },
     "node_modules/scheduler": {
       "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7220,9 +5379,8 @@
     },
     "node_modules/sharp": {
       "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "color": "^4.2.3",
@@ -7259,8 +5417,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -7270,16 +5427,14 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/shiki": {
       "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
-      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
+      "license": "MIT",
       "dependencies": {
         "@shikijs/core": "1.29.2",
         "@shikijs/engine-javascript": "1.29.2",
@@ -7293,8 +5448,7 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -7304,8 +5458,7 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
@@ -7313,13 +5466,11 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+      "license": "MIT"
     },
     "node_modules/sitemap": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
-      "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
@@ -7336,13 +5487,11 @@
     },
     "node_modules/sitemap/node_modules/@types/node": {
       "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -7352,8 +5501,7 @@
     },
     "node_modules/smol-toml": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.1.tgz",
-      "integrity": "sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
       },
@@ -7363,16 +5511,14 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -7380,18 +5526,15 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
-      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -7407,8 +5550,7 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7420,21 +5562,18 @@
     },
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7444,8 +5583,7 @@
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -7457,8 +5595,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -7472,8 +5609,7 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7483,29 +5619,25 @@
     },
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/strnum": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -7525,8 +5657,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7536,8 +5667,7 @@
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7572,8 +5702,7 @@
     },
     "node_modules/tailwindcss/node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -7583,8 +5712,7 @@
     },
     "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -7595,16 +5723,14 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
       }
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -7614,13 +5740,11 @@
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -7630,8 +5754,7 @@
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -7639,8 +5762,7 @@
     },
     "node_modules/trough": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
-      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -7648,13 +5770,11 @@
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+      "license": "Apache-2.0"
     },
     "node_modules/tsconfck": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.4.tgz",
-      "integrity": "sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==",
+      "license": "MIT",
       "bin": {
         "tsconfck": "bin/tsconfck.js"
       },
@@ -7672,13 +5792,11 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
-      "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -7688,13 +5806,11 @@
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
-      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7705,36 +5821,30 @@
     },
     "node_modules/typescript-auto-import-cache": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.5.tgz",
-      "integrity": "sha512-fAIveQKsoYj55CozUiBoj4b/7WpN0i4o74wiGY5JVUEoD0XiqDk1tJqTEjgzL2/AizKQrXxyRosSebyDzBZKjw==",
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.8"
       }
     },
     "node_modules/ufo": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
-      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
+      "license": "MIT"
     },
     "node_modules/ultrahtml": {
       "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.5.3.tgz",
-      "integrity": "sha512-GykOvZwgDWZlTQMtp5jrD4BVL+gNn2NVlVafjcFUJ7taY20tqYdwdoWBFy6GBJsNTZe1GkGPkSl5knQAjtgceg=="
+      "license": "MIT"
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
-      "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
+      "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3",
         "defu": "^6.1.4",
@@ -7745,8 +5855,7 @@
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -7756,8 +5865,7 @@
     },
     "node_modules/unified": {
       "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -7774,8 +5882,7 @@
     },
     "node_modules/unist-util-find-after": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -7787,8 +5894,7 @@
     },
     "node_modules/unist-util-is": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -7799,8 +5905,7 @@
     },
     "node_modules/unist-util-modify-children": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
-      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "array-iterate": "^2.0.0"
@@ -7812,8 +5917,7 @@
     },
     "node_modules/unist-util-position": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -7824,8 +5928,7 @@
     },
     "node_modules/unist-util-remove-position": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
-      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-visit": "^5.0.0"
@@ -7837,8 +5940,7 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -7849,8 +5951,7 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -7863,8 +5964,7 @@
     },
     "node_modules/unist-util-visit-children": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
-      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -7875,8 +5975,7 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -7888,8 +5987,7 @@
     },
     "node_modules/unstorage": {
       "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.14.4.tgz",
-      "integrity": "sha512-1SYeamwuYeQJtJ/USE1x4l17LkmQBzg7deBJ+U9qOBoHo15d1cDxG4jM31zKRgF7pG0kirZy4wVMX6WL6Zoscg==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^3.6.0",
@@ -7979,8 +6077,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7995,6 +6091,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -8008,21 +6105,18 @@
     },
     "node_modules/upper-case": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
@@ -8034,8 +6128,7 @@
     },
     "node_modules/vfile-location": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile": "^6.0.0"
@@ -8047,8 +6140,7 @@
     },
     "node_modules/vfile-message": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0"
@@ -8060,8 +6152,7 @@
     },
     "node_modules/vite": {
       "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
-      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.24.2",
         "postcss": "^8.4.49",
@@ -8130,8 +6221,11 @@
     },
     "node_modules/vitefu": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.5.tgz",
-      "integrity": "sha512-h4Vflt9gxODPFNGPwp4zAMZRpZR7eslzwH2c5hn5kNZ5rhnKyRJ50U+yGCdc2IRaBs8O4haIgLNGrV5CrpMsCA==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*"
+      ],
       "peerDependencies": {
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
       },
@@ -8143,8 +6237,7 @@
     },
     "node_modules/volar-service-css": {
       "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.62.tgz",
-      "integrity": "sha512-JwNyKsH3F8PuzZYuqPf+2e+4CTU8YoyUHEHVnoXNlrLe7wy9U3biomZ56llN69Ris7TTy/+DEX41yVxQpM4qvg==",
+      "license": "MIT",
       "dependencies": {
         "vscode-css-languageservice": "^6.3.0",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -8161,8 +6254,7 @@
     },
     "node_modules/volar-service-emmet": {
       "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.62.tgz",
-      "integrity": "sha512-U4dxWDBWz7Pi4plpbXf4J4Z/ss6kBO3TYrACxWNsE29abu75QzVS0paxDDhI6bhqpbDFXlpsDhZ9aXVFpnfGRQ==",
+      "license": "MIT",
       "dependencies": {
         "@emmetio/css-parser": "^0.4.0",
         "@emmetio/html-matcher": "^1.3.0",
@@ -8180,8 +6272,7 @@
     },
     "node_modules/volar-service-html": {
       "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.62.tgz",
-      "integrity": "sha512-Zw01aJsZRh4GTGUjveyfEzEqpULQUdQH79KNEiKVYHZyuGtdBRYCHlrus1sueSNMxwwkuF5WnOHfvBzafs8yyQ==",
+      "license": "MIT",
       "dependencies": {
         "vscode-html-languageservice": "^5.3.0",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -8198,8 +6289,7 @@
     },
     "node_modules/volar-service-prettier": {
       "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.62.tgz",
-      "integrity": "sha512-h2yk1RqRTE+vkYZaI9KYuwpDfOQRrTEMvoHol0yW4GFKc75wWQRrb5n/5abDrzMPrkQbSip8JH2AXbvrRtYh4w==",
+      "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8"
       },
@@ -8218,8 +6308,7 @@
     },
     "node_modules/volar-service-typescript": {
       "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.62.tgz",
-      "integrity": "sha512-p7MPi71q7KOsH0eAbZwPBiKPp9B2+qrdHAd6VY5oTo9BUXatsOAdakTm9Yf0DUj6uWBAaOT01BSeVOPwucMV1g==",
+      "license": "MIT",
       "dependencies": {
         "path-browserify": "^1.0.1",
         "semver": "^7.6.2",
@@ -8239,8 +6328,7 @@
     },
     "node_modules/volar-service-typescript-twoslash-queries": {
       "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.62.tgz",
-      "integrity": "sha512-KxFt4zydyJYYI0kFAcWPTh4u0Ha36TASPZkAnNY784GtgajerUqM80nX/W1d0wVhmcOFfAxkVsf/Ed+tiYU7ng==",
+      "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8"
       },
@@ -8255,8 +6343,7 @@
     },
     "node_modules/volar-service-yaml": {
       "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.62.tgz",
-      "integrity": "sha512-k7gvv7sk3wa+nGll3MaSKyjwQsJjIGCHFjVkl3wjaSP2nouKyn9aokGmqjrl39mi88Oy49giog2GkZH526wjig==",
+      "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8",
         "yaml-language-server": "~1.15.0"
@@ -8272,8 +6359,7 @@
     },
     "node_modules/vscode-css-languageservice": {
       "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.2.tgz",
-      "integrity": "sha512-GEpPxrUTAeXWdZWHev1OJU9lz2Q2/PPBxQ2TIRmLGvQiH3WZbqaNoute0n0ewxlgtjzTW3AKZT+NHySk5Rf4Eg==",
+      "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
         "vscode-languageserver-textdocument": "^1.0.12",
@@ -8283,8 +6369,7 @@
     },
     "node_modules/vscode-html-languageservice": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.3.1.tgz",
-      "integrity": "sha512-ysUh4hFeW/WOWz/TO9gm08xigiSsV/FOAZ+DolgJfeLftna54YdmZ4A+lIn46RbdO3/Qv5QHTn1ZGqmrXQhZyA==",
+      "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
         "vscode-languageserver-textdocument": "^1.0.12",
@@ -8294,8 +6379,7 @@
     },
     "node_modules/vscode-json-languageservice": {
       "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
-      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -8309,21 +6393,18 @@
     },
     "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
+      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "3.17.5"
       },
@@ -8333,8 +6414,7 @@
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "8.2.0",
         "vscode-languageserver-types": "3.17.5"
@@ -8342,28 +6422,23 @@
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+      "license": "MIT"
     },
     "node_modules/vscode-nls": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
-      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
+      "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8371,8 +6446,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -8385,8 +6459,7 @@
     },
     "node_modules/which-pm": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-3.0.0.tgz",
-      "integrity": "sha512-ysVYmw6+ZBhx3+ZkcPwRuJi38ZOTLJJ33PSHaitLxSKUMsh0LkKd0nC69zZCwt5D+AYUcMK2hhw4yWny20vSGg==",
+      "license": "MIT",
       "dependencies": {
         "load-yaml-file": "^0.2.0"
       },
@@ -8396,16 +6469,14 @@
     },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/widest-line": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
       "dependencies": {
         "string-width": "^7.0.0"
       },
@@ -8418,8 +6489,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -8435,8 +6505,7 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -8451,16 +6520,14 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -8473,13 +6540,11 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8491,8 +6556,7 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8502,26 +6566,22 @@
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
-      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8531,8 +6591,7 @@
     },
     "node_modules/yaml-language-server": {
       "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.15.0.tgz",
-      "integrity": "sha512-N47AqBDCMQmh6mBLmI6oqxryHRzi33aPFPsJhYy3VTUGCdLHYjGh4FZzpUjRlphaADBBkDmnkM/++KNIOHi5Rw==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
         "lodash": "4.17.21",
@@ -8554,21 +6613,18 @@
     },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
-      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="
+      "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/vscode-jsonrpc": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0 || >=10.0.0"
       }
     },
     "node_modules/yaml-language-server/node_modules/vscode-languageserver": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "3.16.0"
       },
@@ -8578,8 +6634,7 @@
     },
     "node_modules/yaml-language-server/node_modules/vscode-languageserver-protocol": {
       "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "6.0.0",
         "vscode-languageserver-types": "3.16.0"
@@ -8587,21 +6642,18 @@
     },
     "node_modules/yaml-language-server/node_modules/vscode-languageserver-types": {
       "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+      "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/yaml": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "license": "ISC",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -8617,29 +6669,25 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8651,8 +6699,7 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8662,8 +6709,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -8673,8 +6719,7 @@
     },
     "node_modules/yocto-spinner": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.0.tgz",
-      "integrity": "sha512-Qu6WAqNLGleB687CCGcmgHIo8l+J19MX/32UrSMfbf/4L8gLoxjpOYoiHT1asiWyqvjRZbgvOhLlvne6E5Tbdw==",
+      "license": "MIT",
       "dependencies": {
         "yoctocolors": "^2.1.1"
       },
@@ -8687,8 +6732,7 @@
     },
     "node_modules/yoctocolors": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
-      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -8698,24 +6742,20 @@
     },
     "node_modules/zod": {
       "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
-      "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
+      "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
       }
     },
     "node_modules/zod-to-ts": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
       "peerDependencies": {
         "typescript": "^4.9.4 || ^5.0.2",
         "zod": "^3"
@@ -8723,23 +6763,10 @@
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "packages/astro-blog-template": {
-      "name": "@wix/astro-blog-template",
-      "version": "0.0.1",
-      "extraneous": true,
-      "dependencies": {
-        "@astrojs/rss": "^4.0.11",
-        "@astrojs/sitemap": "^3.2.1",
-        "@wix/astro-blog-loader": "^0.0.1",
-        "@wix/astro-ricos": "^0.0.1",
-        "astro": "^5.2.4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,8 +55,8 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.11",
         "@astrojs/sitemap": "^3.2.1",
-        "@wix/astro": "^0.2.1",
-        "@wix/astro-ricos": "^0.0.1",
+        "@wix/astro": "^0.2.2",
+        "@wix/astro-ricos": "^0.0.2",
         "astro": "^5.2.4"
       }
     },
@@ -1292,21 +1292,22 @@
       "license": "MIT"
     },
     "node_modules/@wix/astro": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-0.2.1.tgz",
-      "integrity": "sha512-u65AbbRt5//SVtpAo+GEJU+V4IBeCVyQp4SFPeUFDgrtK2luucahW+Hn/ILEdaJ/9RZ6PJpVhsHWsEXUPolWnA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-0.2.2.tgz",
+      "integrity": "sha512-BkUqu+/1EefWoG062xke5YSHwJ9S/M7wGMC6C/ON2jIx0uKbVO5LVJKkQMV0ttlYCzZjIWyib0XKrO9L7n3IWg==",
       "dependencies": {
         "@astrojs/internal-helpers": "0.3.0",
         "@astrojs/underscore-redirects": "^0.4.0",
         "@cloudflare/kv-asset-handler": "^0.3.4",
         "@cloudflare/workers-types": "^4.20241224.0",
-        "@wix/sdk": "^1.15.7",
+        "@wix/blog": "^1.0.345",
+        "@wix/sdk": "^1.15.9",
         "esm-resolve": "^1.0.11",
         "globby": "^14.0.2",
         "magic-string": "^0.30.17"
       },
       "peerDependencies": {
-        "astro": "^5.1.1"
+        "astro": "^5.1.8"
       }
     },
     "node_modules/@wix/astro-blog-template": {
@@ -1314,7 +1315,9 @@
       "link": true
     },
     "node_modules/@wix/astro-ricos": {
-      "version": "0.0.1",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@wix/astro-ricos/-/astro-ricos-0.0.2.tgz",
+      "integrity": "sha512-RR5DT6iQY3f97JTP7h31t+gpCcVKn05tm3cYJpOitK1mcFSxtqucpN2DDukrai/tgwEEARa2aX57XxVaZICN6Q==",
       "dependencies": {
         "@wix/sdk": "^1.15.9"
       },
@@ -1325,6 +1328,73 @@
     "node_modules/@wix/astro/node_modules/@astrojs/internal-helpers": {
       "version": "0.3.0",
       "license": "MIT"
+    },
+    "node_modules/@wix/blog": {
+      "version": "1.0.346",
+      "resolved": "https://registry.npmjs.org/@wix/blog/-/blog-1.0.346.tgz",
+      "integrity": "sha512-dHnoIv5cuP5L9RXvxD9i5XOfNeV6IwCcCPzFO/F5rA2s4xmr5Zu69wyiDvGIqiM4P5HjQxmbYwKNyHPx9snO5A==",
+      "dependencies": {
+        "@wix/blog_blog-cache": "1.0.14",
+        "@wix/blog_blog-importer": "1.0.28",
+        "@wix/blog_categories": "1.0.60",
+        "@wix/blog_draft-posts": "1.0.62",
+        "@wix/blog_posts": "1.0.70",
+        "@wix/blog_tags": "1.0.68"
+      }
+    },
+    "node_modules/@wix/blog_blog-cache": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@wix/blog_blog-cache/-/blog_blog-cache-1.0.14.tgz",
+      "integrity": "sha512-Zqo+H70pSoDTfFNv8a0KztpdfS89lCYtVp2xtK/npV98OzahQpB8IuPztg+Q5oYv0dS/MK8Xo51dS+caAKXXng==",
+      "dependencies": {
+        "@wix/sdk-runtime": "^0.3.22",
+        "@wix/sdk-types": "^1.12.4"
+      }
+    },
+    "node_modules/@wix/blog_blog-importer": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@wix/blog_blog-importer/-/blog_blog-importer-1.0.28.tgz",
+      "integrity": "sha512-/5+dpo5G3P8e5VP6IQX5cF41ANMrzmAlJyhdaGyUOulp0y7yI5Q8MUerm9TEjoWlMMfjhpswYf8kdHsEfqHFzQ==",
+      "dependencies": {
+        "@wix/sdk-runtime": "^0.3.22",
+        "@wix/sdk-types": "^1.12.4"
+      }
+    },
+    "node_modules/@wix/blog_categories": {
+      "version": "1.0.60",
+      "resolved": "https://registry.npmjs.org/@wix/blog_categories/-/blog_categories-1.0.60.tgz",
+      "integrity": "sha512-67W9wOodheYjFsTSNjvfSvSH0YNM223NBonYyMVgsN2ddfr7CnypRs/rvr2X0CdkbeamsBNhBp4KLDhrieI+xA==",
+      "dependencies": {
+        "@wix/sdk-runtime": "^0.3.22",
+        "@wix/sdk-types": "^1.12.4"
+      }
+    },
+    "node_modules/@wix/blog_draft-posts": {
+      "version": "1.0.62",
+      "resolved": "https://registry.npmjs.org/@wix/blog_draft-posts/-/blog_draft-posts-1.0.62.tgz",
+      "integrity": "sha512-fZ5t1stOlacBS1W4Lc6boDq4QdG/6XtTEpQg8t4kZXKutIFCQUOk/T9AZEUi0SfMuURfTzaHIkXYPR6ehqlk4Q==",
+      "dependencies": {
+        "@wix/sdk-runtime": "^0.3.22",
+        "@wix/sdk-types": "^1.12.4"
+      }
+    },
+    "node_modules/@wix/blog_posts": {
+      "version": "1.0.70",
+      "resolved": "https://registry.npmjs.org/@wix/blog_posts/-/blog_posts-1.0.70.tgz",
+      "integrity": "sha512-Z+NPWHshIJu2qT7gkodpylpA8TuLFuxSShXrTRrxY8NSrxnNuoa9ABJsCvtKRSyJloU6AOZPB0j/Atq5zZ2YDw==",
+      "dependencies": {
+        "@wix/sdk-runtime": "^0.3.22",
+        "@wix/sdk-types": "^1.12.4"
+      }
+    },
+    "node_modules/@wix/blog_tags": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@wix/blog_tags/-/blog_tags-1.0.68.tgz",
+      "integrity": "sha512-mYU9dwfIDFK4dqKiFSa4ue45CA27aC22By27VaojEDrojDB7c4sV6J/J4X/oCB2FDPEYfLhMSln8jUJFmCpXEw==",
+      "dependencies": {
+        "@wix/sdk-runtime": "^0.3.22",
+        "@wix/sdk-types": "^1.12.4"
+      }
     },
     "node_modules/@wix/cli-edge": {
       "version": "1.1.60",


### PR DESCRIPTION
This PR refactors the code to import the blog loader directly from @wix-astro instead of the old loader package.

Based on https://github.com/wix-incubator/headless-integrations/pull/4.